### PR TITLE
Bump versions to fix publish on main

### DIFF
--- a/checkout/mint-leaf.yml
+++ b/checkout/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/checkout
-version: 0.0.0
+version: 0.0.1
 
 parameters:
   lfs:

--- a/greeting/mint-leaf.yml
+++ b/greeting/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/greeting
-version: 0.0.0
+version: 0.0.1
 
 parameters:
   name:

--- a/setup-go/mint-leaf.yml
+++ b/setup-go/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-go
-version: 0.0.0
+version: 0.0.1
 
 parameters:
   go-version:

--- a/setup-node/mint-leaf.yml
+++ b/setup-node/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-node
-version: 0.0.0
+version: 0.0.1
 
 parameters:
   node-version:

--- a/setup-ruby/mint-leaf.yml
+++ b/setup-ruby/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-ruby
-version: 0.0.0
+version: 0.0.1
 
 parameters:
   ruby-version:


### PR DESCRIPTION
I'll add a check to Cloud to prevent uploading a leaf with a name and a version that matches a published name+version. That way we'll get a failure on feature branch builds which neglect to bump the version number.