### PR TITLE
Attempt to make zip files deterministic

### DIFF
--- a/.mint/ci.yml
+++ b/.mint/ci.yml
@@ -19,8 +19,9 @@ tasks:
       sudo apt-get install gettext-base jq zip
       sudo apt-get clean
   - key: checkout
-    call: mint/checkout 0.0.0
+    call: mint/checkout 0.0.2
     with:
+      preserve-git-dir: true
       repository: https://github.com/rwx-research/mint-leaves.git
       ref: ${{ init.sha }}
   - key: check-version-consistency
@@ -39,6 +40,9 @@ tasks:
           exit 1
         fi
       done
+    filter:
+      - "*/README.md"
+      - "*/mint-leaf.yml"
   - key: generate-tasks
     use: [system-packages, checkout]
     run: |
@@ -47,3 +51,5 @@ tasks:
       LEAF_NAME=setup-go envsubst '$LEAF_NAME' < per-leaf-tasks.template.yml > $MINT_DYNAMIC_TASKS/setup-go.yml
       LEAF_NAME=setup-node envsubst '$LEAF_NAME' < per-leaf-tasks.template.yml > $MINT_DYNAMIC_TASKS/setup-node.yml
       LEAF_NAME=setup-ruby envsubst '$LEAF_NAME' < per-leaf-tasks.template.yml > $MINT_DYNAMIC_TASKS/setup-ruby.yml
+    filter:
+      - per-leaf-tasks.template.yml

--- a/checkout/README.md
+++ b/checkout/README.md
@@ -6,7 +6,7 @@
 ```yaml
 tasks:
   - key: checkout
-    call: mint/checkout 0.0.2
+    call: mint/checkout 0.0.3
     with:
       repository: git@github.com:YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -27,7 +27,7 @@ To checkout private repositories, you'll need to pass an `ssh-key`.
 ```yaml
 tasks:
   - key: checkout
-    call: mint/checkout 0.0.2
+    call: mint/checkout 0.0.3
     with:
       repository: git@github.com:YOUR_ORG/YOUR_REPO.git
       ref: ${{ init.ref }}

--- a/checkout/mint-leaf.yml
+++ b/checkout/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/checkout
-version: 0.0.2
+version: 0.0.3
 
 parameters:
   lfs:

--- a/greeting/mint-leaf.yml
+++ b/greeting/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/greeting
-version: 0.0.2
+version: 0.0.3
 
 parameters:
   name:

--- a/per-leaf-tasks.template.yml
+++ b/per-leaf-tasks.template.yml
@@ -2,7 +2,7 @@
   use: [system-packages, checkout]
   run: |
     latest_timestamp=$(git ls-files -z $LEAF_NAME | xargs -0 -n1 -I{} -- git log -1 --date=format:"%Y%m%d%H%M" --format="%ad" {} | sort | tail -n 1)
-    echo "$latest_timestamp" | tee $MINT_VALUES/timestamp
+    echo -n "$latest_timestamp" | tee $MINT_VALUES/timestamp
   outputs:
     values:
       - timestamp

--- a/per-leaf-tasks.template.yml
+++ b/per-leaf-tasks.template.yml
@@ -1,6 +1,9 @@
 - key: $LEAF_NAME--build
   use: [system-packages, checkout]
   run: |
+    latest_timestamp=$(git ls-files -z $LEAF_NAME | xargs -0 -n1 -I{} -- git log -1 --date=format:"%Y%m%d%H%M" --format="%ad" {} | sort | tail -n 1)
+    echo "Setting timestamp on files to $latest_timestamp"
+    find $LEAF_NAME -exec touch -t "$latest_timestamp" {}
     cd $LEAF_NAME && zip -X -r ../$LEAF_NAME.zip .
   filter:
     - $LEAF_NAME/**/*

--- a/per-leaf-tasks.template.yml
+++ b/per-leaf-tasks.template.yml
@@ -1,9 +1,18 @@
-- key: $LEAF_NAME--build
+- key: $LEAF_NAME--timestamp
   use: [system-packages, checkout]
   run: |
     latest_timestamp=$(git ls-files -z $LEAF_NAME | xargs -0 -n1 -I{} -- git log -1 --date=format:"%Y%m%d%H%M" --format="%ad" {} | sort | tail -n 1)
-    echo "Setting timestamp on files to $latest_timestamp"
-    find $LEAF_NAME -exec touch -t "$latest_timestamp" {}
+    echo "$latest_timestamp" | tee $MINT_VALUES/timestamp
+  outputs:
+    values:
+      - timestamp
+- key: $LEAF_NAME--build
+  use: [system-packages, checkout]
+  after: [$LEAF_NAME--timestamp]
+  run: |
+    timestamp="${{ tasks.$LEAF_NAME--timestamp.values.timestamp }}"
+    echo "Setting timestamp on files to $timestamp"
+    find $LEAF_NAME -exec touch -t "$timestamp" {}
     cd $LEAF_NAME && zip -X -r ../$LEAF_NAME.zip .
   filter:
     - $LEAF_NAME/**/*

--- a/per-leaf-tasks.template.yml
+++ b/per-leaf-tasks.template.yml
@@ -12,7 +12,7 @@
   run: |
     timestamp="${{ tasks.$LEAF_NAME--timestamp.values.timestamp }}"
     echo "Setting timestamp on files to $timestamp"
-    find $LEAF_NAME -exec touch -t "$timestamp" {}
+    find $LEAF_NAME -exec touch -t "$timestamp" {} \;
     cd $LEAF_NAME && zip -X -r ../$LEAF_NAME.zip .
   filter:
     - $LEAF_NAME/**/*

--- a/setup-go/README.md
+++ b/setup-go/README.md
@@ -5,7 +5,7 @@ To install the latest version of go:
 ```yaml
 tasks:
   - key: go
-    call: mint/setup-go 0.0.2
+    call: mint/setup-go 0.0.3
 ```
 
 To install a specific version:
@@ -13,7 +13,7 @@ To install a specific version:
 ```yaml
 tasks:
   - key: go
-    call: mint/setup-go 0.0.2
+    call: mint/setup-go 0.0.3
     with:
       version: 1.21.5
 ```

--- a/setup-go/mint-leaf.yml
+++ b/setup-go/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-go
-version: 0.0.2
+version: 0.0.3
 
 parameters:
   go-version:

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -6,7 +6,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: mint/setup-node 0.0.2
+    call: mint/setup-node 0.0.3
     with:
       node-version: 21.4.0
 ```
@@ -16,7 +16,7 @@ Or with a file named `.node-version` containing the version of node to install:
 ```yaml
 tasks:
   - key: node
-    call: mint/setup-node 0.0.2
+    call: mint/setup-node 0.0.3
     with:
       node-version-file: .node-version
     filter:

--- a/setup-node/mint-leaf.yml
+++ b/setup-node/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-node
-version: 0.0.2
+version: 0.0.3
 
 parameters:
   node-version:

--- a/setup-ruby/README.md
+++ b/setup-ruby/README.md
@@ -6,7 +6,7 @@ You'll either need to specify `ruby-version` or `ruby-version-file`
 ```yaml
 tasks:
   - key: ruby
-    call: mint/setup-ruby 0.0.2
+    call: mint/setup-ruby 0.0.3
     with:
       ruby-version: 3.2.2
 ```
@@ -16,7 +16,7 @@ Or with a file named `.ruby-version` containing the version of ruby to install:
 ```yaml
 tasks:
   - key: ruby
-    call: mint/setup-ruby 0.0.2
+    call: mint/setup-ruby 0.0.3
     with:
       ruby-version-file: .ruby-version
     filter:

--- a/setup-ruby/mint-leaf.yml
+++ b/setup-ruby/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/setup-ruby
-version: 0.0.2
+version: 0.0.3
 
 parameters:
   ruby-version:


### PR DESCRIPTION
Most of the time, we should get a cache hit on the Mint task which builds the zip file for each leaf. However, if we do not get a cache hit, and we do not modify the leaf, we want to produce a zip file with the same digest as previously built so that we don't release a new version of unchanged leaves.

I adapted some code from this blog post:

https://zerostride.medium.com/building-deterministic-zip-files-with-built-in-commands-741275116a19

And if this doesn't work, we could use a deterministic zip utility such as:

https://github.com/timo-reymann/deterministic-zip