### PR TITLE
Remove publishing leaves to staging

### DIFF
--- a/per-leaf-tasks.template.yml
+++ b/per-leaf-tasks.template.yml
@@ -16,27 +16,7 @@
     cd $LEAF_NAME && zip -X -r ../$LEAF_NAME.zip .
   filter:
     - $LEAF_NAME/**/*
-- key: $LEAF_NAME--upload-staging
-  use: $LEAF_NAME--build
-  run: |
-    curl \
-      --request POST \
-      --fail-with-body \
-      --header "Authorization: Bearer $RWX_ACCESS_TOKEN" \
-      --header 'Accept: application/json' \
-      -F 'file=@$LEAF_NAME.zip' \
-      https://staging.cloud.rwx.com/mint/api/leaves | tee leaves-result.json
-      LEAF_DIGEST=$(cat leaves-result.json | jq -r '.digest')
-      echo -n "$LEAF_DIGEST" > $MINT_VALUES/leaf-digest
-  env:
-    RWX_ACCESS_TOKEN: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN_STAGING_MINT_ORG }}
-  filter:
-    - $LEAF_NAME.zip
-  outputs:
-    values:
-      - leaf-digest
-
-- key: $LEAF_NAME--upload-production
+- key: $LEAF_NAME--upload
   use: $LEAF_NAME--build
   run: |
     curl \

--- a/publish-tasks.template.yml
+++ b/publish-tasks.template.yml
@@ -1,6 +1,6 @@
-- key: $PUBLISH_LEAF_NAME--publish-production
+- key: $PUBLISH_LEAF_NAME--publish
   if: ${{ init.publishleaves }}
-  after: [${PUBLISH_LEAF_NAME}--upload-production,$LEAF_TEST_TASKS]
+  after: [${PUBLISH_LEAF_NAME}--upload,$LEAF_TEST_TASKS]
   run: |
     curl \
       --request POST \
@@ -8,23 +8,7 @@
       --header "Authorization: Bearer $RWX_ACCESS_TOKEN" \
       --header 'Accept: application/json' \
       --header 'Content-Type: application/json' \
-      --data '{ "digest": "${{ tasks.${PUBLISH_LEAF_NAME}--upload-production.values.leaf-digest }}" }' \
+      --data '{ "digest": "${{ tasks.${PUBLISH_LEAF_NAME}--upload.values.leaf-digest }}" }' \
       https://cloud.rwx.com/mint/api/leaves/publish
   env:
     RWX_ACCESS_TOKEN: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN_PRODUCTION_MINT_ORG }}
-- key: $PUBLISH_LEAF_NAME--publish-staging
-  if: ${{ init.publishleaves }}
-  # we publish production first because we test using production Mint
-  # publishing to staging is more about replication so leaves are available there too
-  after: [${PUBLISH_LEAF_NAME}--upload-staging,${PUBLISH_LEAF_NAME}--publish-production]
-  run: |
-    curl \
-      --request POST \
-      --fail-with-body \
-      --header "Authorization: Bearer $RWX_ACCESS_TOKEN" \
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --data '{ "digest": "${{ tasks.${PUBLISH_LEAF_NAME}--upload-staging.values.leaf-digest }}" }' \
-      https://staging.cloud.rwx.com/mint/api/leaves/publish
-  env:
-    RWX_ACCESS_TOKEN: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN_STAGING_MINT_ORG }}


### PR DESCRIPTION
Right now we don't actually need these leaves in staging. If we do end up wanting them there, I think it'd be better for us to set up an out-of-band replication process from production → staging instead. Removing staging from this build will make it easier for this repository to serve as a pattern for other repositories for leaves and will make #19 more straightforward.