### PR TITLE
Replace run ID-based CACHE_BUST with cache:false

### DIFF
--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -6,7 +6,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.2
+    call: mint/git-clone 1.1.3
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -32,7 +32,7 @@ Look in [your default vault](https://cloud.rwx.com/mint/deep_link/vaults) and yo
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.2
+    call: mint/git-clone 1.1.3
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -44,7 +44,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.2
+    call: mint/git-clone 1.1.3
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}

--- a/git-clone/mint-leaf.yml
+++ b/git-clone/mint-leaf.yml
@@ -51,11 +51,11 @@ tasks:
       echo "Latest SHA for ${{ params.ref }}: ${LATEST_SHA_CACHE_BUSTER}"
       printf "${LATEST_SHA_CACHE_BUSTER}" >> "$MINT_VALUES/latest-sha-cache-buster"
     env:
-      CACHE_BUST: ${{ mint.run.id }}
       GIT_SSH_KEY: ${{ params.ssh-key }}
       GITHUB_ACCESS_TOKEN: ${{ params.github-access-token }}
     outputs:
       values: [latest-sha-cache-buster]
+    cache: false
   - key: install-lfs
     run: |
       if [[ '${{ params.lfs }}' != 'true' ]]; then

--- a/git-clone/mint-leaf.yml
+++ b/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.1.2
+version: 1.1.3
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 
 parameters:


### PR DESCRIPTION
The `latest-sha-cache-buster` output is unaffected, but we always want to run the task that determines the latest sha based on the provided ref.