### PR TITLE
Fixes setting the credential helper when cloning

### DIFF
--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -1,12 +1,11 @@
 # mint/git-clone
 
-
 ## Clone Public Repositories
 
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.4
+    call: mint/git-clone 1.1.5
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -32,7 +31,7 @@ Look in [your default vault](https://cloud.rwx.com/mint/deep_link/vaults) and yo
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.4
+    call: mint/git-clone 1.1.5
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -44,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.1.4
+    call: mint/git-clone 1.1.5
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}

--- a/git-clone/mint-leaf.yml
+++ b/git-clone/mint-leaf.yml
@@ -1,28 +1,28 @@
 name: mint/git-clone
-version: 1.1.4
+version: 1.1.5
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 
 parameters:
   github-access-token:
-    description: 'Token to clone from GitHub over HTTPS'
+    description: "Token to clone from GitHub over HTTPS"
     required: false
   lfs:
     description: Whether to download Git-LFS files
     default: false
   path:
-    description: 'The relative path within the workspace into which the repository will be cloned'
-    default: './'
+    description: "The relative path within the workspace into which the repository will be cloned"
+    default: "./"
   preserve-git-dir:
-    description: 'Whether or not to preserve the .git directory. Set to true if you want to perform git operations like committing after cloning. Preserving the .git directory will decreaes the likelihood of cache hits when a file filter is not specified.'
+    description: "Whether or not to preserve the .git directory. Set to true if you want to perform git operations like committing after cloning. Preserving the .git directory will decreaes the likelihood of cache hits when a file filter is not specified."
     default: false
   ref:
-    description: 'The ref to check out of the git repository'
+    description: "The ref to check out of the git repository"
     required: true
   repository:
-    description: 'The url of a git repository.'
+    description: "The url of a git repository."
     required: true
   ssh-key:
-    description: 'The ssh key to use if cloning over ssh'
+    description: "The ssh key to use if cloning over ssh"
     required: false
 
 tasks:
@@ -71,7 +71,7 @@ tasks:
   - key: git-clone
     use: [setup, install-lfs]
     run: |
-      git ${{ tasks.setup.values.credentials-arg }} clone ${{ params.repository }} ${{ params.path }}
+      git clone ${{ tasks.setup.values.credentials-arg }} ${{ params.repository }} ${{ params.path }}
       cd ${{ params.path }}
 
       git checkout ${{ params.ref }}


### PR DESCRIPTION
Turns out that `git -c ... clone` is different than `git clone -c ...`. This updates our clone command so that it sets the credential helper config in the repository for future git commands to use. 