### PR TITLE
Ensure leaf fails when session name is too long

### DIFF
--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -8,7 +8,7 @@ tasks:
     call: aws/install-cli 1.0.0
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.0.0
+    call: aws/assume-role 1.0.1
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -23,7 +23,7 @@ tasks:
     call: aws/install-cli 1.0.0
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.0.0
+    call: aws/assume-role 1.0.1
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -39,7 +39,7 @@ tasks:
     call: aws/install-cli 1.0.0
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.0.0
+    call: aws/assume-role 1.0.1
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -55,7 +55,7 @@ tasks:
     call: aws/install-cli 1.0.0
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.0.0
+    call: aws/assume-role 1.0.1
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2

--- a/aws/assume-role/mint-ci-cd.template.yml
+++ b/aws/assume-role/mint-ci-cd.template.yml
@@ -21,14 +21,3 @@
 - key: aws--assume-role--test--specified-profile-name--assert
   use: aws--assume-role--test--specified-profile-name
   run: aws sts get-caller-identity --profile custom-profile &> /dev/null # avoid leaking account/role info
-- key: aws--assume-role--test--session-name-too-long
-  use: aws--assume-role--install-cli
-  call: $LEAF_DIGEST
-  with:
-    oidc-token: ${{ vaults.mint_leaves_aws_assume_role_testing.oidc.aws_token }}
-    region: us-east-2
-    role-to-assume: ${{ vaults.mint_leaves_aws_assume_role_testing.secrets.ROLE_TO_ASSUME }}
-    role-session-name: some-really-really-really-super-long-session-name-should-fail-${{ mint.run.id }}
-- key: aws--assume-role--test--session-name-too-long--assert
-  use: aws--assume-role--test--session-name-too-long
-  run: aws sts get-caller-identity &> /dev/null # avoid leaking account/role info

--- a/aws/assume-role/mint-ci-cd.template.yml
+++ b/aws/assume-role/mint-ci-cd.template.yml
@@ -21,3 +21,14 @@
 - key: aws--assume-role--test--specified-profile-name--assert
   use: aws--assume-role--test--specified-profile-name
   run: aws sts get-caller-identity --profile custom-profile &> /dev/null # avoid leaking account/role info
+- key: aws--assume-role--test--session-name-too-long
+  use: aws--assume-role--install-cli
+  call: $LEAF_DIGEST
+  with:
+    oidc-token: ${{ vaults.mint_leaves_aws_assume_role_testing.oidc.aws_token }}
+    region: us-east-2
+    role-to-assume: ${{ vaults.mint_leaves_aws_assume_role_testing.secrets.ROLE_TO_ASSUME }}
+    role-session-name: some-really-really-really-super-long-session-name-should-fail-${{ mint.run.id }}
+- key: aws--assume-role--test--session-name-too-long--assert
+  use: aws--assume-role--test--session-name-too-long
+  run: aws sts get-caller-identity &> /dev/null # avoid leaking account/role info

--- a/aws/assume-role/mint-leaf.yml
+++ b/aws/assume-role/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: aws/assume-role
-version: 1.0.0
+version: 1.0.1
 description: Assume an AWS role
 
 parameters:

--- a/aws/assume-role/mint-leaf.yml
+++ b/aws/assume-role/mint-leaf.yml
@@ -40,14 +40,16 @@ tasks:
         role_session_name="assumed-role-for-mint-run-${{ mint.run.id }}"
       fi
 
-      export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" \
-        $(aws sts assume-role-with-web-identity \
+      sts_result=$(
+        aws sts assume-role-with-web-identity \
         --role-arn "${{ params.role-to-assume }}" \
         --role-session-name "$role_session_name" \
         --web-identity-token "${{ params.oidc-token }}" \
         --duration-seconds ${{ params.role-duration-seconds }} \
         --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text))
+        --output text
+      )
+      export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" $sts_result)
 
       aws configure set region "${{ params.region }}" --profile ${{ params.profile-name }}
       aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile ${{ params.profile-name }}


### PR DESCRIPTION
Non-zero exits within a subshell do not bubble up. This change ensures failures within `assume-role-with-web-identity` fail the leaf.

Note: I could not leave the demonstrating test in as we have no way to continue on failures and then inspect the outcome of a leaf today.