### PR TITLE
Fix install-go

### DIFF
--- a/mint/install-go/README.md
+++ b/mint/install-go/README.md
@@ -5,7 +5,7 @@ To install the latest version of go:
 ```yaml
 tasks:
   - key: go
-    call: mint/install-go 1.0.4
+    call: mint/install-go 1.0.5
 ```
 
 To install a specific version:
@@ -13,7 +13,12 @@ To install a specific version:
 ```yaml
 tasks:
   - key: go
-    call: mint/install-go 1.0.4
+    call: mint/install-go 1.0.5
     with:
       go-version: 1.21.5
 ```
+
+If the patch version is omitted, the latest patch version for the given minor
+version will be downloaded.
+
+A minor or patch version must be specified.

--- a/mint/install-go/README.md
+++ b/mint/install-go/README.md
@@ -22,3 +22,11 @@ If the patch version is omitted, the latest patch version for the given minor
 version will be downloaded.
 
 A minor or patch version must be specified.
+
+## Checksum verification
+
+`mint/install-go` downloads go binaries from https://go.dev/dl/. Most downloads
+include a sha256 checksum that is verified. However, some downloads of older go
+versions include only a sha1 checksum, that is not made available via the API
+that `mint/install-go` uses. For such downloads, checksum verification is
+skipped.

--- a/mint/install-go/bin/install-go
+++ b/mint/install-go/bin/install-go
@@ -36,14 +36,14 @@ if [ -d "${install_dir}" ]; then
 fi
 
 function cleanup {
-  # TODO(doug): mintignore these instead of removing
   echo "Cleaning up"
   sudo apt-get clean
   rm -rf "$source_dir"
 }
 trap cleanup EXIT
 
-releases="$(curl -sL "https://golang.org/dl/?mode=json" | jq -r "[.[].files[] | select(.filename | test(\"go${target_version}.+${os}-${architecture}.tar.gz\"; \"sx\"))][0]")"
+escaped_target_version="${target_version//./\\\\.}"
+releases="$(curl -sL "https://golang.org/dl/?mode=json&include=all" | jq -r "[.[].files[] | select(.filename | test(\"go${escaped_target_version}(\\\\.[0-9]+)?\\\\.${os}-${architecture}.tar.gz\"; \"sx\"))][0]")"
 filename=$(echo "$releases" | jq -r .filename )
 shasum=$(echo "$releases" | jq -r .sha256 )
 

--- a/mint/install-go/bin/install-go
+++ b/mint/install-go/bin/install-go
@@ -51,8 +51,12 @@ echo "Downloading ${filename}"
 mkdir -p "$source_dir"
 curl -sL "https://golang.org/dl/${filename}" -o "${source_dir}/${filename}"
 
-echo "Verifying checksum"
-echo "${shasum} ${source_dir}/${filename}" | sha256sum -c -
+if [ "$shasum" == "" ]; then
+  echo "SHA256 checksum not found for ${target_version}; skipping verification"
+else
+  echo "Verifying checksum"
+  echo "${shasum} ${source_dir}/${filename}" | sha256sum -c -
+fi
 
 echo "Extracting to ${install_dir}"
 mkdir -p "$install_dir"

--- a/mint/install-go/mint-ci-cd.template.yml
+++ b/mint/install-go/mint-ci-cd.template.yml
@@ -5,3 +5,17 @@
 - key: install-go--test-confirm
   use: install-go--test
   run: go version | grep 1.20
+- key: install-go--test-old-version
+  call: $LEAF_DIGEST
+  with:
+    go-version: "1.2"
+- key: install-go--test-old-version-confirm
+  use: install-go--test-old-version
+  run: go version | grep 1.2
+- key: install-go--test-version-with-patch
+  call: $LEAF_DIGEST
+  with:
+    go-version: "1.20.14"
+- key: install-go--test-version-with-patch-confirm
+  use: install-go--test-version-with-patch
+  run: go version | grep 1.20.14

--- a/mint/install-go/mint-leaf.yml
+++ b/mint/install-go/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-go
-version: 1.0.4
+version: 1.0.5
 description: Install the Go programming language
 
 parameters:


### PR DESCRIPTION
- Download all versions from golang.org when fetching releases. Without "include=all", only the last two majors are fetched.

- Fix the test for the target go version. Previously we would match the regex `${target_version}.+`, but this would download `go1.20` if you really wanted 1.2.