### PR TITLE
Slim down default google-cloud/install-cli leaf output.

### DIFF
--- a/google-cloud/install-cli/README.md
+++ b/google-cloud/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Google Cloud CLI:
 ```yaml
 tasks:
   - key: gcloud-cli
-    call: google-cloud/install-cli 1.0.0
+    call: google-cloud/install-cli 1.0.1
 ```
 
 To install a specific version of the Google Cloud CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Google Cloud CLI:
 ```yaml
 tasks:
   - key: gcloud-cli
-    call: google-cloud/install-cli 1.0.0
+    call: google-cloud/install-cli 1.0.1
     with:
       cli-version: "465.0.0"
 ```

--- a/google-cloud/install-cli/mint-leaf.yml
+++ b/google-cloud/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google-cloud/install-cli
-version: 1.0.0
+version: 1.0.1
 description: Install the Google Cloud SDK CLI
 
 parameters:
@@ -41,6 +41,7 @@ tasks:
       echo "Extracting to ${install_dir}/google-cloud-sdk"
       mkdir -p "$install_dir"
       tar -xf "$filename" -C "$install_dir"
+      rm "$filename"
 
       echo
       echo "Running installer"
@@ -56,10 +57,13 @@ tasks:
       echo "Checking installation"
       gcloud --version
 
-  - key: install-cli-components
-    use: install-cli
-    run: |
       if [[ "${{ params.components }}" != "" ]]; then
+        echo
+        echo "Installing components"
         IFS=" " read -r -a components <<< "${{ params.components }}"
         gcloud components install "${components[@]}"
       fi
+
+      echo
+      echo "Cleaning Google Cloud SDK backup"
+      rm -rf "${install_dir}/google-cloud-sdk/.install/.backup"


### PR DESCRIPTION
Remove the original downloaded file and delete the installation "backup," which `gcloud` makes whenever you add/remove components. The resulting layer is less than half the size it was before. (Still not great, but closer to `aws/install-cli`.)