### PR TITLE
Fix flake in terraform tests

### DIFF
--- a/hashicorp/install-terraform/mint-ci-cd.template.yml
+++ b/hashicorp/install-terraform/mint-ci-cd.template.yml
@@ -3,7 +3,10 @@
 
 - key: hashicorp--install-terraform--test-default--assert
   use: hashicorp--install-terraform--test-default
-  run: terraform --version | head -1 | grep -E 'Terraform v[0-9]'
+  run: |
+    version=$(terraform --version | head -n 1)
+    echo "$version"
+    echo "$version" | grep -E 'Terraform v[0-9]'
 
 #-----
 
@@ -14,4 +17,7 @@
 
 - key: hashicorp--install-terraform--test-specified--assert
   use: hashicorp--install-terraform--test-specified
-  run: terraform --version | head -1 | grep -E 'Terraform v1\.7\.3'
+  run: |
+    version=$(terraform --version | head -n 1)
+    echo "$version"
+    echo "$version" | grep 'Terraform v1\.7\.3'


### PR DESCRIPTION
Failed on `main` in this run:

https://cloud.rwx.com/mint/rwx/runs/48ed04c48fd547b086ce5fbc3d2cc58b

Presumably due to this isseu:

https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q