### PR TITLE
Periodically bust the cache for mint/install-cli

### DIFF
--- a/mint/install-cli/README.md
+++ b/mint/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.2
+    call: mint/install-cli 1.0.3
 ```
 
 To install a specific version of the Mint CLI:
@@ -13,9 +13,9 @@ To install a specific version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.2
+    call: mint/install-cli 1.0.3
     with:
-      cli-version: v0.0.12
+      cli-version: v0.2.0
 ```
 
 For the list of available versions, see the releases on GitHub:

--- a/mint/install-cli/mint-leaf.yml
+++ b/mint/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-cli
-version: 1.0.2
+version: 1.0.3
 description: Install the Mint CLI
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/install-cli
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -10,7 +10,17 @@ parameters:
     default: 'v0'
 
 tasks:
+  - key: cache-ttl
+    cache: false
+    run: |
+      if [[ "${{ params.cli-version }}" == "v0" ]]; then
+        date +%F | tee $MINT_VALUES/cache-ttl
+      else
+        echo "" | tee $MINT_VALUES/cache-ttl
+      fi
+
   - key: install
+    use: []
     run: |
       version="${{ params.cli-version }}"
       tmp="$(mktemp -d)/mint"
@@ -18,3 +28,5 @@ tasks:
       sudo install "$tmp" /usr/local/bin
       rm "$tmp"
       mint --version
+    env:
+      CACHE_TTL: ${{ tasks.cache-ttl.values.cache-ttl }}


### PR DESCRIPTION
Updates `mint/install-cli` to fetch the latest `v0` daily if specifying `v0` for the version