### PR TITLE
Add mint/update-leaves-github.

### DIFF
--- a/mint/update-leaves-github/README.md
+++ b/mint/update-leaves-github/README.md
@@ -1,0 +1,53 @@
+# mint/update-leaves-github
+
+Update the versions of Mint leaves used in a GitHub repository.
+When updates are available, open or update a pull request.
+
+The provided `github-access-token` should be for a
+[private GitHub App](https://www.rwx.com/docs/mint/guides/github-automation)
+with repository permissions for:
+
+- Contents: read and write
+- Pull Requests: read and write
+
+If you would like to automatically create the `label`, additionally provide:
+
+- Issues: read and write
+- Projects: read only (see [github/cli discussion](https://github.com/cli/cli/discussions/5307))
+
+To update minor versions (recommended):
+
+```yaml
+tasks:
+  - key: mint-update-leaves
+    call: mint/update-leaves-github 1.0.0
+    with:
+      repository: https://github.com/YOUR-ORG/YOUR-REPO.git
+      ref: ${{ init.commit-sha }}
+      github-access-token: ${{ vaults.MY_VAULT.github-apps.MY-GITHUB-APP.token }}
+      rwx-access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
+```
+
+Customize the label and color name:
+
+```yaml
+tasks:
+  - key: mint-update-leaves
+    call: mint/update-leaves-github 1.0.0
+    with:
+      repository: https://github.com/YOUR-ORG/YOUR-REPO.git
+      ref: ${{ init.commit-sha }}
+      github-access-token: ${{ vaults.MY_VAULT.github-apps.MY-GITHUB-APP.token }}
+      rwx-access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
+      label: mint-updates
+      label-color: "298F21"
+```
+
+Setting `label` to an empty string will skip labeling new pull requests.
+
+Pull requests that may be eligible for update are any for this repository
+that have been created by your private GitHub App and, if not set to an empty
+string, having the provided `label`.
+
+**If you reuse the same private GitHub App for other tasks, you should not set
+`label` to an empty string. When not provided, it will default to `mint-updates`.**

--- a/mint/update-leaves-github/mint-ci-cd.template.yml
+++ b/mint/update-leaves-github/mint-ci-cd.template.yml
@@ -1,0 +1,214 @@
+- key: update-leaves-github--gh-cli
+  call: github/install-cli 1.0.0
+
+- key: update-leaves-github--jq-cli
+  run: |
+    sudo apt-get update
+    sudo apt-get install -y jq
+    sudo apt-get clean
+
+- key: update-leaves-github--test-create
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/mint-update-leaves-testing.git
+    ref: main
+    github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
+    label: "mint-leaves-test-${{ mint.run.id }}"
+    mint-file: tasks.yml
+
+- key: update-leaves-github--test-create--assert
+  after: update-leaves-github--test-create
+  use: [update-leaves-github--gh-cli, update-leaves-github--jq-cli]
+  run: |
+    PR_NUMBER="$(gh --repo rwx-research/mint-update-leaves-testing pr list --author '@me' --label "$GITHUB_LABEL" --json number --jq 'max_by(.number) | .number')"
+    if [ -z "$PR_NUMBER" ]; then
+      >&2 echo "Pull request not found"
+      exit 4
+    fi
+    printf "$PR_NUMBER" > "$MINT_VALUES/pr-number"
+
+    # Check PR body
+    pr_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json body | jq -r '.body')"
+    grep -q "Updated the following leaves" <<< "$pr_body" || { echo "Update header not found" && exit 4; }
+    grep -q "mint/install-go 1.0.0 ->" <<< "$pr_body" || { echo "Update mint/install-go not found" && exit 4; }
+    grep -q "mint/install-node 1.0.0 ->" <<< "$pr_body" || { echo "Update mint/install-node not found" && exit 4; }
+
+    # Check PR diff
+    pr_diff="$(gh --repo rwx-research/mint-update-leaves-testing pr diff "$PR_NUMBER")"
+    grep -q "\-    call: mint/install-go 1.0.0" <<< "$pr_diff" || { echo "Delete install-go 1.0.0 not found" && exit 4; }
+    grep -q "+    call: mint/install-go 1." <<< "$pr_diff" || { echo "Add install-go 1.x.x not found" && exit 4; }
+    grep -q "\-    call: mint/install-node 1.0.0" <<< "$pr_diff" || { echo "Delete install-node 1.0.0 not found" && exit 4; }
+    grep -q "+    call: mint/install-node 1." <<< "$pr_diff" || { echo "Add install-node 1.x.x not found" && exit 4; }
+
+    # Verify no comments (until after update)
+    comment_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json comments | jq '.comments | length')"
+    if [ "$comment_count" != "0" ]; then
+      echo "PR #${PR_NUMBER} has $comment_count comments, expected 0"
+      exit 4
+    fi
+
+    commit_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json commits | jq '.commits | length')"
+    if [ "$commit_count" != 1 ]; then
+      echo "PR #${PR_NUMBER} has $commit_count commits, expected 1"
+      exit 4
+    fi
+  outputs:
+    values: [pr-number]
+  env:
+    GITHUB_LABEL: mint-leaves-test-${{ mint.run.id }}
+    GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+
+- key: clone-test-repo
+  call: mint/git-clone 1.1.12
+  with:
+    repository: https://github.com/rwx-research/mint-update-leaves-testing.git
+    ref: main
+    preserve-git-dir: true
+    github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+
+- key: update-leaves-github--test--partial-revert
+  after: update-leaves-github--test-create--assert
+  use: [update-leaves-github--gh-cli, clone-test-repo]
+  run: |
+    gh --repo rwx-research/mint-update-leaves-testing pr checkout "$PR_NUMBER"
+
+    # Revert the install-go change.
+    sed -i -E "s/call: mint\/install-go\s+1.+$/call: mint\/install-go 1.0.0/" tasks.yml
+
+    if git diff --quiet; then
+      echo "Unable to make replacement for mint/install-go in tasks.yml"
+      exit 4
+    fi
+
+    git commit --all -m "Reset changes to install-go for testing."
+    git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+
+    for i in {0..15}; do
+      commit_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json commits | jq '.commits | length')"
+      if [ "$commit_count" -eq 2 ]; then
+        break
+      fi
+      sleep 1
+    done
+    if [ "$commit_count" != 2 ]; then
+      echo "PR #${PR_NUMBER} has $commit_count commits, expected 2"
+      exit 4
+    fi
+
+    # Ensure changes we just made have reset install-go.
+    pr_diff="$(gh --repo rwx-research/mint-update-leaves-testing pr diff "$PR_NUMBER")"
+    grep -qv "\-    call: mint/install-go 1.0.0" <<< "$pr_diff" || { echo "Found change for mint/install-go when none was expected" && exit 4; }
+    # Still have install-node changes.
+    grep -q "\-    call: mint/install-node 1.0.0" <<< "$pr_diff" || { echo "Delete install-node 1.0.0 not found" && exit 4; }
+    grep -q "+    call: mint/install-node 1." <<< "$pr_diff" || { echo "Add install-node 1.x.x not found" && exit 4; }
+
+    # Later, ensure the update doesn't reset the PR body (since it'll be a partial change).
+    gh --repo rwx-research/mint-update-leaves-testing pr edit "$PR_NUMBER" --body "Body reset for testing"
+  env:
+    GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    PR_NUMBER: ${{ tasks.update-leaves-github--test-create--assert.values.pr-number }}
+
+- key: update-leaves-github--test-update-changes
+  after: update-leaves-github--test--partial-revert
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/mint-update-leaves-testing.git
+    ref: main
+    github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
+    label: "mint-leaves-test-${{ mint.run.id }}"
+    mint-file: tasks.yml
+
+- key: update-leaves-github--test-update-changes--assert
+  after: ${{ update-leaves-github--test-update-changes.succeeded && update-leaves-github--test-create--assert.succeeded }}
+  use: [update-leaves-github--gh-cli, update-leaves-github--jq-cli]
+  run: |
+    # PR body should not have changes.
+    pr_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json body | jq -r '.body')"
+    grep -q "Body reset for testing" <<< "$pr_body" || { echo "PR body has not been reset for testing" && exit 4; }
+
+    for i in {0..15}; do
+      commit_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json commits | jq '.commits | length')"
+      if [ "$commit_count" -eq 3 ]; then
+          break
+      fi
+      sleep 1
+    done
+    if [ "$commit_count" != 3 ]; then
+      echo "PR #${PR_NUMBER} has $commit_count commits, expected 3"
+      exit 4
+    fi
+
+    pr_diff="$(gh --repo rwx-research/mint-update-leaves-testing pr diff "$PR_NUMBER")"
+    grep -q "\-    call: mint/install-go 1.0.0" <<< "$pr_diff" || { echo "Delete install-go 1.0.0 not found" && exit 4; }
+    grep -q "+    call: mint/install-go 1." <<< "$pr_diff" || { echo "Add install-go 1.x.x not found" && exit 4; }
+    grep -q "\-    call: mint/install-node 1.0.0" <<< "$pr_diff" || { echo "Delete install-node 1.0.0 not found" && exit 4; }
+    grep -q "+    call: mint/install-node 1." <<< "$pr_diff" || { echo "Add install-node 1.x.x not found" && exit 4; }
+
+    comment_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json comments | jq '.comments | length')"
+    if [ "$comment_count" != "1" ]; then
+      echo "PR #${PR_NUMBER} has $comment_count comments, expected 1"
+      exit 4
+    fi
+
+    # We only reset changes to install-go, so the comment shouldn't include install-node.
+    comment_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json comments | jq -r '.comments[0].body')"
+    grep -q "Updated the following leaves" <<< "$comment_body" || { echo "Update header not found" && exit 4; }
+    grep -q "mint/install-go 1.0.0 ->" <<< "$comment_body" || { echo "Update mint/install-go not found" && exit 4; }
+    grep -qv "mint/install-node 1.0.0 ->" <<< "$comment_body" || { echo "Update mint/install-node found" && exit 4; }
+  env:
+    GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    PR_NUMBER: ${{ tasks.update-leaves-github--test-create--assert.values.pr-number }}
+
+- key: update-leaves-github--test-update-no-changes
+  after: update-leaves-github--test-update-changes--assert
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/mint-update-leaves-testing.git
+    ref: main
+    github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
+    label: "mint-leaves-test-${{ mint.run.id }}"
+    mint-file: tasks.yml
+
+- key: update-leaves-github--test-update-no-changes--assert
+  after: ${{ update-leaves-github--test-update-no-changes.succeeded && update-leaves-github--test-create--assert.succeeded }}
+  use: [update-leaves-github--gh-cli, update-leaves-github--jq-cli]
+  run: |
+    for i in {0..15}; do
+      commit_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json commits | jq '.commits | length')"
+      if [ "$commit_count" -eq 3 ]; then
+          break
+      fi
+      sleep 1
+    done
+    if [ "$commit_count" != 3 ]; then
+      echo "PR #${PR_NUMBER} has $commit_count commits, expected 3"
+      exit 4
+    fi
+
+    comment_count="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json comments | jq '.comments | length')"
+    if [ "$comment_count" != "1" ]; then
+      echo "PR #${PR_NUMBER} has $comment_count comments, expected 1"
+      exit 4
+    fi
+  env:
+    GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    PR_NUMBER: ${{ tasks.update-leaves-github--test-create--assert.values.pr-number }}
+
+- key: update-leaves-github--test--cleanup
+  use: update-leaves-github--gh-cli
+  after: ${{ update-leaves-github--test-update-no-changes--assert.finished }}
+  run: |
+    PR_NUMBER="$(gh --repo rwx-research/mint-update-leaves-testing pr list --author '@me' --label "$GITHUB_LABEL" --json number --jq 'max_by(.number) | .number')"
+    if [ -n "$PR_NUMBER" ]; then
+      gh --repo rwx-research/mint-update-leaves-testing pr close "$PR_NUMBER" --delete-branch
+    fi
+
+    if gh --repo rwx-research/mint-update-leaves-testing label list --search "$GITHUB_LABEL" | grep -qv "no labels"; then
+      gh --repo rwx-research/mint-update-leaves-testing label delete "$GITHUB_LABEL" --yes
+    fi
+  env:
+    GITHUB_LABEL: mint-leaves-test-${{ mint.run.id }}
+    GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -1,0 +1,121 @@
+name: mint/update-leaves-github
+version: 1.0.0
+description: Update Mint leaves for GitHub
+source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/update-leaves-github
+issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
+
+parameters:
+  rwx-access-token:
+    description: "RWX_ACCESS_TOKEN used to authenticate the Mint CLI"
+    required: true
+  repository:
+    description: "GitHub HTTPS repository URL"
+    required: true
+  ref:
+    description: "The ref to check out of the git repository"
+    required: true
+  github-access-token:
+    description: "The GitHub access token to a private app"
+    required: true
+  allow-major-version-change:
+    description: "Allow updating across major versions"
+    default: false
+  label:
+    description: "Label for opened pull requests"
+    default: "mint-updates"
+  label-color:
+    description: "Label color if not yet created"
+    default: "298F21"
+  mint-file:
+    description: "Scope updates to a specific file or files"
+
+tasks:
+  - key: install-mint
+    call: mint/install-cli 1.0.3
+
+  - key: install-gh
+    call: github/install-cli 1.0.0
+
+  - key: code
+    call: mint/git-clone 1.1.12
+    with:
+      repository: ${{ params.repository }}
+      ref: ${{ params.ref }}
+      github-access-token: ${{ params.github-access-token }}
+      preserve-git-dir: true
+
+  - key: update-leaves
+    use: [install-mint, install-gh, code]
+    cache: false
+    run: |
+      pr_number="$(gh pr list --author '@me' ${GITHUB_LABEL:+--label "$GITHUB_LABEL"} --json number --jq 'max_by(.number) | .number')"
+      if [ -n "$pr_number" ]; then
+        printf "$pr_number" > "$MINT_VALUES/existing-pr"
+        gh pr checkout "$pr_number"
+      else
+        touch "$MINT_VALUES/existing-pr"
+        branch="mint-update-$MINT_RUN_ID"
+        git checkout -b "$branch"
+      fi
+
+      mint_args=()
+      if [ "$ALLOW_MAJOR_VERSION_CHANGE" = "true" ]; then
+        mint_args+=("--allow-major-version-change")
+      fi
+
+      if [ -n "$MINT_FILE" ]; then
+        mint_args+=("$MINT_FILE")
+      fi
+
+      mint leaves update "${mint_args[@]}" 2>&1 | tee "$MINT_VALUES/mint-leaves-update-output"
+
+      if [ -n "$(git status --porcelain)" ]; then
+        git add -u
+        git commit -F- <<EOF
+      Update Mint leaves to the latest version.
+
+      $(cat "$MINT_VALUES/mint-leaves-update-output")
+      EOF
+        git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+        printf "true" > "$MINT_VALUES/has-changes"
+      else
+        echo "No changes detected."
+        printf "false" > "$MINT_VALUES/has-changes"
+      fi
+    outputs:
+      values:
+        - existing-pr
+        - has-changes
+        - mint-leaves-update-output
+    env:
+      ALLOW_MAJOR_VERSION_CHANGE: ${{ params.allow-major-version-change }}
+      GITHUB_LABEL: ${{ params.label }}
+      GITHUB_TOKEN: ${{ params.github-access-token }}
+      RWX_ACCESS_TOKEN: ${{ params.rwx-access-token }}
+      MINT_FILE: ${{ params.mint-file}}
+      MINT_RUN_ID: ${{ mint.run.id }}
+
+  - key: create-or-update-pr
+    use: update-leaves
+    run: |
+      if [ "$HAS_CHANGES" != "true" ]; then
+        # Conditional tasks are not supported within a leaf (yet), so this task always runs.
+        exit 0
+      fi
+
+      if [ -z "$GITHUB_PR_NUMBER" ]; then
+        if [ -n "$GITHUB_LABEL" ]; then
+          gh label create "$GITHUB_LABEL" --color "$GITHUB_LABEL_COLOR" || true
+        fi
+
+        gh pr create --fill ${GITHUB_LABEL:+--label "$GITHUB_LABEL"}
+      else
+        gh pr comment "$GITHUB_PR_NUMBER" --body "$MINT_LEAVES_UPDATE_OUTPUT"
+      fi
+    env:
+      GITHUB_TOKEN: ${{ params.github-access-token }}
+      GITHUB_LABEL: ${{ params.label }}
+      GITHUB_LABEL_COLOR: ${{ params.label-color }}
+      GITHUB_PR_NUMBER: ${{ tasks.update-leaves.values.existing-pr }}
+      HAS_CHANGES: ${{ tasks.update-leaves.values.has-changes }}
+      MINT_LEAVES_UPDATE_OUTPUT: ${{ tasks.update-leaves.values.mint-leaves-update-output }}


### PR DESCRIPTION
Use `mint` to update leaves and open a pull request. If a pull request is opened, it will update it if there are changes.

If there are changes on a PR update, it will add the new changes in a new commit and make a comment on the PR. We may want to update the PR's description on update, but it'd be fiddling with outputs of `mint leaves update`.

Here's a PR in the testing repo that captures the lifecycle of the automated test: https://github.com/rwx-research/mint-update-leaves-testing/pull/13