### PR TITLE
Remove rwx-access-token parameter from mint/update-leaves-github.

### DIFF
--- a/mint/update-leaves-github/README.md
+++ b/mint/update-leaves-github/README.md
@@ -25,7 +25,6 @@ tasks:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
       github-access-token: ${{ vaults.MY_VAULT.github-apps.MY-GITHUB-APP.token }}
-      rwx-access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
 ```
 
 Customize the label and color name:
@@ -38,7 +37,6 @@ tasks:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
       github-access-token: ${{ vaults.MY_VAULT.github-apps.MY-GITHUB-APP.token }}
-      rwx-access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
       label: mint-updates
       label-color: "298F21"
 ```

--- a/mint/update-leaves-github/README.md
+++ b/mint/update-leaves-github/README.md
@@ -20,7 +20,7 @@ To update minor versions (recommended):
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.0
+    call: mint/update-leaves-github 1.0.1
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -32,7 +32,7 @@ Customize the label and color name:
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.0
+    call: mint/update-leaves-github 1.0.1
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}

--- a/mint/update-leaves-github/mint-ci-cd.template.yml
+++ b/mint/update-leaves-github/mint-ci-cd.template.yml
@@ -13,7 +13,6 @@
     repository: https://github.com/rwx-research/mint-update-leaves-testing.git
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
-    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
     label: "mint-leaves-test-${{ mint.run.id }}"
     mint-file: tasks.yml
 
@@ -116,7 +115,6 @@
     repository: https://github.com/rwx-research/mint-update-leaves-testing.git
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
-    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
     label: "mint-leaves-test-${{ mint.run.id }}"
     mint-file: tasks.yml
 
@@ -168,7 +166,6 @@
     repository: https://github.com/rwx-research/mint-update-leaves-testing.git
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
-    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
     label: "mint-leaves-test-${{ mint.run.id }}"
     mint-file: tasks.yml
 

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -5,9 +5,6 @@ source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/upda
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
 
 parameters:
-  rwx-access-token:
-    description: "RWX_ACCESS_TOKEN used to authenticate the Mint CLI"
-    required: true
   repository:
     description: "GitHub HTTPS repository URL"
     required: true
@@ -91,7 +88,6 @@ tasks:
       ALLOW_MAJOR_VERSION_CHANGE: ${{ params.allow-major-version-change }}
       GITHUB_LABEL: ${{ params.label }}
       GITHUB_TOKEN: ${{ params.github-access-token }}
-      RWX_ACCESS_TOKEN: ${{ params.rwx-access-token }}
       MINT_FILE: ${{ params.mint-file}}
       MINT_RUN_ID: ${{ mint.run.id }}
 

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/update-leaves-github
-version: 1.0.0
+version: 1.0.1
 description: Update Mint leaves for GitHub
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/update-leaves-github
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
`mint leaves update` [no longer requires RWX authentication](https://github.com/rwx-research/mint-cli/pull/68), so don't require an `rwx-access-token`. 🎉 