### PR TITLE
Expose cache-excluded metadata to tasks which use `mint/git-clone`

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -95,7 +95,7 @@ The SHA of the resolved commit.
 
 The unresolved ref associated with the commit. Mint attempts to determine this for you, but in some scenarios you may want to specify. The logic is as follows:
 
-- If you have provided the `meta-ref` parameter, we'll use that (note: you can specify the fully qualified ref with `refs/heads/` or `refs/tags/` prefix or the short name)
+- If you have provided the `meta-ref` parameter, we'll use that (note: you can specify the fully qualified ref including its `refs/heads/` or `refs/tags/` prefix, or you can specify only the short name)
 - If you provide a commit sha to the `ref` parameter, we'll try to find a branch or tag which contains it
 - If you provide a branch or tag to the `ref` parameter, we'll use that (again, you can provide a fully qualified ref or short ref name)
 

--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -96,8 +96,9 @@ The SHA of the resolved commit.
 The unresolved ref associated with the commit. Mint attempts to determine this for you, but in some scenarios you may want to specify. The logic is as follows:
 
 - If you have provided the `meta-ref` parameter, we'll use that (note: you can specify the fully qualified ref including its `refs/heads/` or `refs/tags/` prefix, or you can specify only the short name)
-- If you provide a commit sha to the `ref` parameter, we'll try to find a branch or tag which contains it
+- If you provide a commit sha to the `ref` parameter, we'll try to find a branch or tag with that commit at HEAD
 - If you provide a branch or tag to the `ref` parameter, we'll use that (again, you can provide a fully qualified ref or short ref name)
+- If no other case catches your ref, we'll use the resolved commit sha
 
 ### `MINT_GIT_REF_NAME`
 

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -66,3 +66,148 @@
     test $GIT_USERNAME = "rwx-mint[bot]"
   env:
     GITHUB_TOKEN: ${{ secrets.RWX_RESEARCH_CLONE_TOKEN }}
+
+- key: git-clone--test-commit-sha-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-commit-sha-ref-meta--assert
+  use: git-clone--test-commit-sha-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/heads/main" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/heads/main, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-explicit-branch-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: refs/heads/main
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-explicit-branch-ref-meta--assert
+  use: git-clone--test-explicit-branch-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/heads/main" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/heads/main, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-implicit-branch-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: main
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-implicit-branch-ref-meta--assert
+  use: git-clone--test-implicit-branch-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/heads/main" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/heads/main, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-explicit-tag-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: refs/tags/v1
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-explicit-tag-ref-meta--assert
+  use: git-clone--test-explicit-tag-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/tags/v1" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/tags/v1, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-implicit-tag-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: v1
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-implicit-tag-ref-meta--assert
+  use: git-clone--test-implicit-tag-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/tags/v1" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/tags/v1, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-meta-ref-override
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: v1
+    meta-ref: main
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-meta-ref-override--assert
+  use: git-clone--test-meta-ref-override
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/heads/main" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/heads/main, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
+- key: git-clone--test-ssh-repo-name
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: main
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-ssh-repo-name--assert
+  use: git-clone--test-ssh-repo-name
+  run: |
+    if [[ "$MINT_GIT_REPOSITORY_NAME" != "rwx-research/test-checkout-leaf" ]]; then
+      echo "Expected MINT_GIT_REPOSITORY_NAME to be rwx-research/test-checkout-leaf, got $MINT_GIT_REPOSITORY_NAME"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REPOSITORY_NAME:
+      cache-key: included
+
+- key: git-clone--test-https-repo-name
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: main
+    github-access-token: ${{ secrets.RWX_RESEARCH_CLONE_TOKEN }}
+
+- key: git-clone--test-https-repo-name--assert
+  use: git-clone--test-https-repo-name
+  run: |
+    if [[ "$MINT_GIT_REPOSITORY_NAME" != "rwx-research/test-checkout-leaf" ]]; then
+      echo "Expected MINT_GIT_REPOSITORY_NAME to be rwx-research/test-checkout-leaf, got $MINT_GIT_REPOSITORY_NAME"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REPOSITORY_NAME:
+      cache-key: included

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -80,7 +80,7 @@ tasks:
 
       git checkout ${{ params.ref }}
 
-      commit_sha=$(git rev-parse HEAD)
+      commit_sha=$(git rev-parse HEAD | tr -d '\n')
       echo "Checked out git repository at ${commit_sha}"
 
       if [[ "${{ params.lfs }}" == "true" ]]; then
@@ -109,11 +109,15 @@ tasks:
           exit 1
         fi
       elif [[ "${{ params.ref }}" == "${commit_sha}" ]]; then
-        refs_containing_sha=$(git for-each-ref --format="%(refname)" --contains | grep -v refs/remotes)
-        unresolved_ref=$(echo "$refs_containing_sha" | head -n 1 | tr -d '\n')
+        refs_with_sha_at_head=$(git for-each-ref | grep -v refs/remotes/ | awk "\$1 ~ /^${commit_sha}/" | awk '{ print $3; }')
+        unresolved_ref=$(echo "$refs_with_sha_at_head" | head -n 1 | tr -d '\n')
       else
         refs_matching_provided_ref=$(git for-each-ref --format="%(refname)" "refs/heads/${{ params.ref }}" "refs/tags/${{ params.ref }}" "${{ params.ref }}" | grep -v refs/remotes)
         unresolved_ref=$(echo "$refs_matching_provided_ref" | head -n 1 | tr -d '\n')
+      fi
+
+      if [[ -z "${unresolved_ref}" ]]; then
+        unresolved_ref="${commit_sha}"
       fi
 
       if [[ -n "${unresolved_ref}" ]]; then

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.1.14
+version: 1.2.0
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -20,6 +20,9 @@ parameters:
   ref:
     description: "The ref to check out of the git repository"
     required: true
+  meta-ref:
+    description: "The unresolved name of the ref being checked out (used to set MINT_GIT_REF_NAME). e.g. refs/heads/main or refs/tags/v1.0.0"
+    required: false
   repository:
     description: "The url of a git repository."
     required: true
@@ -77,11 +80,45 @@ tasks:
 
       git checkout ${{ params.ref }}
 
-      echo "Checked out git repository at $(git rev-parse HEAD)"
+      commit_sha=$(git rev-parse HEAD)
+      echo "Checked out git repository at ${commit_sha}"
 
       if [[ "${{ params.lfs }}" == "true" ]]; then
         git lfs fetch
         git lfs checkout
+      fi
+
+      # Set metadata
+      printf "${{ params.repository }}" >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_REPOSITORY_URL"
+      printf "${{ params.repository }}" | tr ':' '/' | rev | cut -d '/' -f1,2 | rev | sed 's/\.git$//' >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_REPOSITORY_NAME"
+      commit_message=$(git log -n 1 --pretty=format:%B)
+      printf "${commit_message}" >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_COMMIT_MESSAGE"
+      printf "${commit_sha}" >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_COMMIT_SHA"
+
+      unresolved_ref=""
+      if [[ -n "${{ params.meta-ref }}" ]]; then
+        refs_matching_provided_ref=$(git for-each-ref --format="%(refname)" "refs/heads/${{ params.meta-ref }}" "refs/tags/${{ params.meta-ref }}" "${{ params.meta-ref }}" | grep -v refs/remotes)
+        unresolved_ref=$(echo "$refs_matching_provided_ref" | head -n 1 | tr -d '\n')
+
+        # also, ensure the meta-ref contains the resolved commit sha
+        result=$(git for-each-ref "${unresolved_ref}" --format="%(refname)" --contains "${commit_sha}")
+        if [[ -z "${result}" ]]; then
+          cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
+      The \`meta-ref\` provided does not contain the resolved commit sha.
+      EOF
+          exit 1
+        fi
+      elif [[ "${{ params.ref }}" == "${commit_sha}" ]]; then
+        refs_containing_sha=$(git for-each-ref --format="%(refname)" --contains | grep -v refs/remotes)
+        unresolved_ref=$(echo "$refs_containing_sha" | head -n 1 | tr -d '\n')
+      else
+        refs_matching_provided_ref=$(git for-each-ref --format="%(refname)" "refs/heads/${{ params.ref }}" "refs/tags/${{ params.ref }}" "${{ params.ref }}" | grep -v refs/remotes)
+        unresolved_ref=$(echo "$refs_matching_provided_ref" | head -n 1 | tr -d '\n')
+      fi
+
+      if [[ -n "${unresolved_ref}" ]]; then
+        printf "${unresolved_ref}" >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_REF"
+        printf "${unresolved_ref}" | sed -E 's|refs/[^/]+/||' >> "$MINT_CACHE_KEY_EXCLUDED_ENV/MINT_GIT_REF_NAME"
       fi
 
       if [[ "${{ params.preserve-git-dir }}" == "false" ]]; then


### PR DESCRIPTION
This version of `mint/git-clone` exposes metadata to tasks which `use` this leaf. The change sets new environment variables which are configured to have no impact to subsequent tasks' cache keys by default. With no additional configuration, it's safe to use these as metadata for tools which request additional context of the environment they run in (e.g. code coverage, parallel test runners, etc.).

In the worst case (using `meta-ref`) this has 3 extra git commands. In other cases, it has 2 extra.