### PR TITLE
 Fixes determining the MINT_GIT_REF for commit SHAs that are not on main 

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.3
+    call: mint/git-clone 1.2.4
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -32,7 +32,7 @@ Look in [your default vault](https://cloud.rwx.com/mint/deep_link/vaults) and yo
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.3
+    call: mint/git-clone 1.2.4
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -44,7 +44,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.3
+    call: mint/git-clone 1.2.4
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -62,7 +62,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.3
+    call: mint/git-clone 1.2.4
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -85,6 +85,24 @@
     MINT_GIT_REF:
       cache-key: included
 
+- key: git-clone--test-commit-sha-non-main-ref-meta
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: 4704503c51f6b5dd6346e219888488ed693dc54c
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+
+- key: git-clone--test-commit-sha-non-main-ref-meta--assert
+  use: git-clone--test-commit-sha-non-main-ref-meta
+  run: |
+    if [[ "$MINT_GIT_REF" != "refs/heads/do-not-delete-this-branch" ]]; then
+      echo "Expected MINT_GIT_REF to be refs/heads/do-not-delete-this-branch, got $MINT_GIT_REF"
+      exit 1
+    fi
+  env:
+    MINT_GIT_REF:
+      cache-key: included
+
 - key: git-clone--test-explicit-branch-ref-meta
   call: $LEAF_DIGEST
   with:

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.2.3
+version: 1.2.4
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -109,10 +109,12 @@ tasks:
 
       unresolved_ref=""
       if [[ -n "${META_REF}" ]]; then
-        refs_matching_provided_ref=$(git for-each-ref --format="%(refname)" "refs/heads/${META_REF}" "refs/tags/${META_REF}" "${META_REF}" | grep -v refs/remotes)
+        refs_matching_provided_ref=$(git ls-remote --heads --tags origin | grep "refs/heads/${META_REF}\|refs/tags/${META_REF}\|${META_REF}" | awk '{ print $2; }')
         unresolved_ref=$(echo "$refs_matching_provided_ref" | head -n 1 | tr -d '\n')
 
         # also, ensure the meta-ref contains the resolved commit sha
+        # first fetch the ref so it will appear in git for-each-ref under refs/heads or refs/tags
+        git fetch origin "${unresolved_ref}:${unresolved_ref}"
         result=$(git for-each-ref "${unresolved_ref}" --format="%(refname)" --contains "${commit_sha}")
         if [[ -z "${result}" ]]; then
           cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
@@ -121,10 +123,10 @@ tasks:
           exit 1
         fi
       elif [[ "${CHECKOUT_REF}" == "${commit_sha}" ]]; then
-        refs_with_sha_at_head=$(git for-each-ref | grep -v refs/remotes/ | awk "\$1 ~ /^${commit_sha}/" | awk '{ print $3; }')
+        refs_with_sha_at_head=$(git ls-remote --heads --tags origin | awk "\$1 ~ /^${commit_sha}/" | awk '{ print $2; }')
         unresolved_ref=$(echo "$refs_with_sha_at_head" | head -n 1 | tr -d '\n')
       else
-        refs_matching_provided_ref=$(git for-each-ref --format="%(refname)" "refs/heads/${CHECKOUT_REF}" "refs/tags/${CHECKOUT_REF}" "${CHECKOUT_REF}" | grep -v refs/remotes)
+        refs_matching_provided_ref=$(git ls-remote  --heads --tags origin | grep "refs/heads/${CHECKOUT_REF}\|refs/tags/${CHECKOUT_REF}\|${CHECKOUT_REF}" | awk '{ print $2; }')
         unresolved_ref=$(echo "$refs_matching_provided_ref" | head -n 1 | tr -d '\n')
       fi
 

--- a/mint/update-leaves-github/README.md
+++ b/mint/update-leaves-github/README.md
@@ -20,7 +20,7 @@ To update minor versions (recommended):
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.3
+    call: mint/update-leaves-github 1.0.4
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -32,7 +32,7 @@ Customize the label and color name:
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.3
+    call: mint/update-leaves-github 1.0.4
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}

--- a/mint/update-leaves-github/mint-ci-cd.template.yml
+++ b/mint/update-leaves-github/mint-ci-cd.template.yml
@@ -30,8 +30,8 @@
     # Check PR body
     pr_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json body | jq -r '.body')"
     grep -q "Updated the following leaves" <<< "$pr_body" || { echo "Update header not found" && exit 4; }
-    grep -q "mint/install-go 1.0.0 ->" <<< "$pr_body" || { echo "Update mint/install-go not found" && exit 4; }
-    grep -q "mint/install-node 1.0.0 ->" <<< "$pr_body" || { echo "Update mint/install-node not found" && exit 4; }
+    grep -q "mint/install-go 1.0.0 →" <<< "$pr_body" || { echo "Update mint/install-go not found" && exit 4; }
+    grep -q "mint/install-node 1.0.0 →" <<< "$pr_body" || { echo "Update mint/install-node not found" && exit 4; }
 
     # Check PR diff
     pr_diff="$(gh --repo rwx-research/mint-update-leaves-testing pr diff "$PR_NUMBER")"
@@ -153,8 +153,8 @@
     # We only reset changes to install-go, so the comment shouldn't include install-node.
     comment_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json comments | jq -r '.comments[0].body')"
     grep -q "Updated the following leaves" <<< "$comment_body" || { echo "Update header not found" && exit 4; }
-    grep -q "mint/install-go 1.0.0 ->" <<< "$comment_body" || { echo "Update mint/install-go not found" && exit 4; }
-    grep -qv "mint/install-node 1.0.0 ->" <<< "$comment_body" || { echo "Update mint/install-node found" && exit 4; }
+    grep -q "mint/install-go 1.0.0 →" <<< "$comment_body" || { echo "Update mint/install-go not found" && exit 4; }
+    grep -qv "mint/install-node 1.0.0 →" <<< "$comment_body" || { echo "Update mint/install-node found" && exit 4; }
   env:
     GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
     PR_NUMBER: ${{ tasks.update-leaves-github--test-create--assert.values.pr-number }}

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/update-leaves-github
-version: 1.0.3
+version: 1.0.4
 description: Update Mint leaves for GitHub repositories
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/update-leaves-github
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
`git for-each-ref` only returns branches and tags under `refs/heads` and `refs/tags` that you have locally; all the remote-only branches are only available under the prefix `refs/remotes`. This updates the clone leaf to use `git ls-remote --heads --tags` instead.

Our test didn't catch this because it used the latest commit on main, but main _is_ checked out locally so it didn't reproduce the issue. I added another test for a non-main commit which does reproduce it.