### PR TITLE
[mint/update-leaves-github] Use branch name to find open PRs.

### DIFF
--- a/mint/update-leaves-github/README.md
+++ b/mint/update-leaves-github/README.md
@@ -20,7 +20,7 @@ To update minor versions (recommended):
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.4
+    call: mint/update-leaves-github 1.0.5
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}
@@ -32,7 +32,7 @@ Customize the label and color name:
 ```yaml
 tasks:
   - key: mint-update-leaves
-    call: mint/update-leaves-github 1.0.4
+    call: mint/update-leaves-github 1.0.5
     with:
       repository: https://github.com/YOUR-ORG/YOUR-REPO.git
       ref: ${{ init.commit-sha }}

--- a/mint/update-leaves-github/mint-ci-cd.template.yml
+++ b/mint/update-leaves-github/mint-ci-cd.template.yml
@@ -14,6 +14,7 @@
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
     label: "mint-leaves-test-${{ mint.run.id }}"
+    branch-prefix: "mint-leaves-test/${{ mint.run.id }}/"
     mint-file: tasks.yml
 
 - key: update-leaves-github--test-create--assert
@@ -26,6 +27,13 @@
       exit 4
     fi
     printf "$PR_NUMBER" > "$MINT_VALUES/pr-number"
+
+    # Check branch name
+    branch_name="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')"
+    if [[ "$branch_name" != "$BRANCH_PREFIX"* ]]; then
+      >&2 echo "Expected branch name to match \"${BRANCH_PREFIX}*\", but got \"$branch_name\""
+      exit 4
+    fi
 
     # Check PR body
     pr_body="$(gh --repo rwx-research/mint-update-leaves-testing pr view "$PR_NUMBER" --json body | jq -r '.body')"
@@ -57,6 +65,7 @@
   env:
     GITHUB_LABEL: mint-leaves-test-${{ mint.run.id }}
     GITHUB_TOKEN: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
+    BRANCH_PREFIX: "mint-leaves-test/${{ mint.run.id }}/"
 
 - key: clone-test-repo
   call: mint/git-clone 1.1.14
@@ -116,6 +125,7 @@
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
     label: "mint-leaves-test-${{ mint.run.id }}"
+    branch-prefix: "mint-leaves-test/${{ mint.run.id }}/"
     mint-file: tasks.yml
 
 - key: update-leaves-github--test-update-changes--assert
@@ -167,6 +177,7 @@
     ref: main
     github-access-token: ${{ vaults.mint_leaves_development.github-apps.mint-mint-leaves-development.token }}
     label: "mint-leaves-test-${{ mint.run.id }}"
+    branch-prefix: "mint-leaves-test/${{ mint.run.id }}/"
     mint-file: tasks.yml
 
 - key: update-leaves-github--test-update-no-changes--assert

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -17,6 +17,9 @@ parameters:
   allow-major-version-change:
     description: "Allow updating across major versions"
     default: false
+  branch-prefix:
+    description: "Branch prefix for opened pull requests"
+    default: "mint-update-"
   label:
     description: "Label for opened pull requests"
     default: "mint-updates"
@@ -45,13 +48,13 @@ tasks:
     use: [install-mint, install-gh, code]
     cache: false
     run: |
-      pr_number="$(gh pr list --author '@me' ${GITHUB_LABEL:+--label "$GITHUB_LABEL"} --json number --jq 'max_by(.number) | .number')"
+      pr_number=$(gh pr list --author @me --json number,headRefName --jq "[.[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}\"))] | max_by(.number) | .number")
       if [ -n "$pr_number" ]; then
         printf "$pr_number" > "$MINT_VALUES/existing-pr"
         gh pr checkout "$pr_number"
       else
         touch "$MINT_VALUES/existing-pr"
-        branch="mint-update-$MINT_RUN_ID"
+        branch="${BRANCH_PREFIX}${MINT_RUN_ID}"
         git checkout -b "$branch"
       fi
 
@@ -88,6 +91,7 @@ tasks:
         - mint-leaves-update-output
     env:
       ALLOW_MAJOR_VERSION_CHANGE: ${{ params.allow-major-version-change }}
+      BRANCH_PREFIX: ${{ params.branch-prefix }}
       GITHUB_LABEL: ${{ params.label }}
       GITHUB_TOKEN: ${{ params.github-access-token }}
       MINT_FILE: ${{ params.mint-file}}

--- a/mint/update-leaves-github/mint-leaf.yml
+++ b/mint/update-leaves-github/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/update-leaves-github
-version: 1.0.4
+version: 1.0.5
 description: Update Mint leaves for GitHub repositories
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/update-leaves-github
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
We believe using the branch name will be safer than using labels. The only PRs to be considered will still be constrained to those opened by the same private GitHub App.