### PR TITLE
[google-cloud/auth-oidc] Add service token lifetime parameter.

### DIFF
--- a/google-cloud/auth-oidc/README.md
+++ b/google-cloud/auth-oidc/README.md
@@ -8,7 +8,7 @@ To authenticate with Google Cloud using OIDC and direct Workload Identity Federa
 ```yaml
 tasks:
   - key: gcloud-login
-    call: google-cloud/auth-oidc 1.0.2
+    call: google-cloud/auth-oidc 1.0.3
     with:
       oidc-token: ${{ vaults.your-vault.oidc.gcp }}
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
@@ -19,7 +19,7 @@ To authenticate with Google Cloud using OIDC and a Service Account:
 ```yaml
 tasks:
   - key: gcloud-login
-    call: google-cloud/auth-oidc 1.0.2
+    call: google-cloud/auth-oidc 1.0.3
     with:
       oidc-token: ${{ vaults.your-vault.oidc.gcp }}
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}
@@ -31,7 +31,7 @@ A `project-id` may optionally be provided to select an active project for `gclou
 ```yaml
 tasks:
   - key: gcloud-login
-    call: google-cloud/auth-oidc 1.0.2
+    call: google-cloud/auth-oidc 1.0.3
     with:
       oidc-token: ${{ vaults.your-vault.oidc.gcp }}
       workload-identity-provider: ${{ vaults.your-vault.secrets.WORKLOAD_IDENTITY_PROVIDER }}

--- a/google-cloud/auth-oidc/mint-ci-cd.template.yml
+++ b/google-cloud/auth-oidc/mint-ci-cd.template.yml
@@ -1,5 +1,5 @@
 - key: google-cloud--auth-oidc--install-cli
-  call: google-cloud/install-cli 1.0.1
+  call: google-cloud/install-cli 1.0.3
 
 - key: google-cloud--auth-oidc--test--direct-workload
   use: google-cloud--auth-oidc--install-cli

--- a/google-cloud/auth-oidc/mint-ci-cd.template.yml
+++ b/google-cloud/auth-oidc/mint-ci-cd.template.yml
@@ -27,5 +27,63 @@
   run: |
     gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
       grep -q "$SERVICE_ACCOUNT"
+
+    now=$(date)
+    gcloud_auth_describe="$(gcloud auth describe "$SERVICE_ACCOUNT")"
+
+    # gcloud outputs in mm-dd-YYYY HH:MM:SS format, whicha GNU date doesn't understand.
+    raw_expiry=$(echo "$gcloud_auth_describe" | grep '^expiry:' | cut -d' ' -f2- | sed -E 's/^([0-9]{2})-([0-9]{2})-([0-9]{4})/\3-\1-\2/')
+    expiry=$(date --date="$raw_expiry")
+    now_seconds=$(date --date="$now" +%s)
+    expiry_seconds=$(date --date="$expiry" +%s)
+    lifetime_seconds=$((now_seconds - expiry_seconds))
+
+    echo
+    echo "Service account token expires: $expiry"
+    echo "Now: $now"
+    echo "Token remaining lifetime seconds: $lifetime_seconds"
+  env:
+    SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
+
+- key: google-cloud--auth-oidc--test--service-account-with-lifetime
+  use: google-cloud--auth-oidc--install-cli
+  call: $LEAF_DIGEST
+  with:
+    oidc-token: ${{ vaults.mint_leaves_google_cloud_auth_testing.oidc.gcp }}
+    workload-identity-provider: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+    service-account: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}
+    service-account-token-lifetime-seconds: 63
+- key: google-cloud--auth-oidc--test--service-account-with-lifetime--assert
+  use: google-cloud--auth-oidc--test--service-account-with-lifetime
+  run: |
+    expected_lifetime_seconds=63
+    echo "Active accounts:"
+    gcloud auth list --filter="status:ACTIVE" --format="value(account)" | \
+      grep -q "$SERVICE_ACCOUNT"
+
+    now=$(date)
+    gcloud_auth_describe="$(gcloud auth describe "$SERVICE_ACCOUNT")"
+
+    if ! grep -q "token_lifetime_seconds:.*${expected_lifetime_seconds}" <<< "$gcloud_auth_describe"; then
+      >&2 echo "Unable to find matching token_lifetime_seconds of ${expected_token_lifetime} in active auth config"
+      exit 1
+    fi
+
+    # gcloud outputs in mm-dd-YYYY HH:MM:SS format, whicha GNU date doesn't understand.
+    raw_expiry=$(echo "$gcloud_auth_describe" | grep '^expiry:' | cut -d' ' -f2- | sed -E 's/^([0-9]{2})-([0-9]{2})-([0-9]{4})/\3-\1-\2/')
+    expiry=$(date --date="$raw_expiry")
+    now_seconds=$(date --date="$now" +%s)
+    expiry_seconds=$(date --date="$expiry" +%s)
+    lifetime_seconds=$((now_seconds - expiry_seconds))
+
+    echo
+    echo "Service account token expires: $expiry"
+    echo "Now: $now"
+    echo "Token remaining lifetime seconds: $lifetime_seconds"
+
+    if [ "$lifetime_seconds" -gte $(($expected_lifetime_seconds + 5)) ]; then
+      >&2 echo "Expected remaining lifetime seconds to be under $(($expected_lifetime_seconds + 5))"
+      exit 1
+    fi
   env:
     SERVICE_ACCOUNT: ${{ vaults.mint_leaves_google_cloud_auth_testing.secrets.GCP_SERVICE_ACCOUNT }}

--- a/google-cloud/auth-oidc/mint-leaf.yml
+++ b/google-cloud/auth-oidc/mint-leaf.yml
@@ -14,6 +14,9 @@ parameters:
   service-account:
     description: "The identifier of the Google Cloud service account which will be impersonated by the generated OIDC"
     required: false
+  service-account-token-lifetime-seconds:
+    description: "Lifetime duration of the service account access token in seconds"
+    required: false
   audience:
     description: "The generated token's `aud` parameter, defaults to the value of `workload-identity-provider`"
     required: false
@@ -85,6 +88,13 @@ tasks:
         credentials_content=$(echo "$credentials_content" | \
           jq --arg url "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${{ params.service-account }}:generateAccessToken" \
             '.service_account_impersonation_url = $url')
+
+        if [[ -n "${{ params.service-account-token-lifetime-seconds }}" ]]; then
+          echo "Setting service account token lifetime to ${{ params.service-account-token-lifetime-seconds }} seconds"
+          credentials_content=$(echo "$credentials_content" | \
+            jq --arg lifetime "${{ params.service-account-token-lifetime-seconds }}" \
+              '.service_account_impersonation += {"token_lifetime_seconds": $lifetime}')
+        fi
       fi
 
       echo "$credentials_content" >"$credentials_file"

--- a/google-cloud/auth-oidc/mint-leaf.yml
+++ b/google-cloud/auth-oidc/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google-cloud/auth-oidc
-version: 1.0.2
+version: 1.0.3
 description: Authenticate to Google Cloud with OIDC and Workload Identity Federation
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/google-cloud/auth-oidc
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
Expose the underlying service token lifetime configuration offered by gcloud.