### PR TITLE
Remove the jq task from git-clone

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.5
+    call: mint/git-clone 1.2.6
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -32,7 +32,7 @@ Look in [your default vault](https://cloud.rwx.com/mint/deep_link/vaults) and yo
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.5
+    call: mint/git-clone 1.2.6
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -44,7 +44,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.5
+    call: mint/git-clone 1.2.6
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -62,7 +62,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.5
+    call: mint/git-clone 1.2.6
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.2.5
+version: 1.2.6
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -156,13 +156,8 @@ tasks:
       LFS: ${{ params.lfs }}
       PRESERVE_GIT_DIR: ${{ params.preserve-git-dir }}
 
-  - key: jq
-    run: |
-      sudo apt-get update
-      sudo apt-get install jq
-      sudo apt-get clean
   - key: configure-git
-    use: [git-clone, jq]
+    use: [git-clone]
     run: |
       if [[ "${PRESERVE_GIT_DIR}" == "false" ]]; then
         exit 0


### PR DESCRIPTION
This is no longer needed now that we include `jq` in the base image