### PR TITLE
Add a leaf to install elixir

### DIFF
--- a/mint/install-elixir/README.md
+++ b/mint/install-elixir/README.md
@@ -1,0 +1,22 @@
+# mint/install-elixir
+
+To install Elixir, you'll need to have Erlang installed.
+
+```yaml
+tasks:
+  - key: erlang
+    call: mint/install-erlang 1.0.0
+    with:
+      erlang-version: 26.2.3
+
+  - key: elixir
+    use: erlang
+    call: mint/install-elixir 1.0.0
+    with:
+      elixir-version: 1.17.2
+```
+
+## Supported Versions
+
+This leaf installs Elixir using precompiled binaries.
+See [the GitHub releases](https://github.com/elixir-lang/elixir/releases) for supported versions.

--- a/mint/install-elixir/mint-ci-cd.template.yml
+++ b/mint/install-elixir/mint-ci-cd.template.yml
@@ -1,0 +1,19 @@
+- key: erlang-25
+  call: 6d64f700c16d68e32696f6d89ba501b80a4c9f46a5486e0d6a0f6d7cecbe43be
+  with:
+    erlang-version: 25.0.3
+
+- key: erlang-26
+  call: 6d64f700c16d68e32696f6d89ba501b80a4c9f46a5486e0d6a0f6d7cecbe43be
+  with:
+    erlang-version: 26.2.3
+
+- key: install-1-17-2-on-25
+  use: erlang-25
+  call: $LEAF_DIGEST
+  with:
+    elixir-version: 1.17.2
+
+- key: install-1-17-2-on-25--assert
+  use: install-1-17-2-on-25
+  run: elixir --version

--- a/mint/install-elixir/mint-ci-cd.template.yml
+++ b/mint/install-elixir/mint-ci-cd.template.yml
@@ -1,10 +1,10 @@
 - key: erlang-25
-  call: 6d64f700c16d68e32696f6d89ba501b80a4c9f46a5486e0d6a0f6d7cecbe43be
+  call: mint/install-erlang 1.0.0
   with:
     erlang-version: 25.0.3
 
 - key: erlang-26
-  call: 6d64f700c16d68e32696f6d89ba501b80a4c9f46a5486e0d6a0f6d7cecbe43be
+  call: mint/install-erlang 1.0.0
   with:
     erlang-version: 26.2.3
 

--- a/mint/install-elixir/mint-ci-cd.template.yml
+++ b/mint/install-elixir/mint-ci-cd.template.yml
@@ -16,4 +16,16 @@
 
 - key: install-1-17-2-on-25--assert
   use: install-1-17-2-on-25
-  run: elixir --version
+  run: |
+    elixir --version | grep '^Elixir 1\.17\.2'
+
+- key: install-1-17-2-on-26
+  use: erlang-26
+  call: $LEAF_DIGEST
+  with:
+    elixir-version: 1.17.2
+
+- key: install-1-17-2-on-26--assert
+  use: install-1-17-2-on-26
+  run: |
+    elixir --version | grep '^Elixir 1\.17\.2'

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -1,0 +1,33 @@
+name: mint/install-elixir
+version: 1.0.0
+description: Install Elixir, a dynamic, functional language for building scalable and maintainable applications.
+source_code_url: https://github.com/rwx-research/mint-leaves/tree/mint/install-elixir
+issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
+
+parameters:
+  elixir-version:
+    description: "Version of Elixir to install"
+    required: true
+
+tasks:
+  - key: install
+    run: |
+      erlang_major_version=$(erl -eval 'erlang:display(list_to_integer(erlang:system_info(otp_release))), halt().' -noshell | tr -d '\r\n')
+      if [[ $? -ne 0 ]]; then
+        echo "failed to determine version of erlang"
+        exit 1
+      fi
+      echo "Downloading Elixir for Erlang version ${erlang_major_version}"
+
+      file="elixir-otp-${erlang_major_version}.zip"
+      mkdir $HOME/elixir
+      cd $HOME/elixir
+      echo "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/${file}"
+      curl -LO "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/${file}"
+      unzip "$file"
+      rm "$file"
+      echo "$HOME/elixir/bin" > $MINT_ENV/PATH
+
+      bin/elixir --version
+    env:
+      ELIXIR_VERSION: ${{ params.elixir-version }}

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -15,6 +15,12 @@ tasks:
       erlang_major_version=$(erl -eval 'erlang:display(list_to_integer(erlang:system_info(otp_release))), halt().' -noshell | tr -d '\r\n')
       if [[ $? -ne 0 ]]; then
         echo "failed to determine version of erlang"
+        cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
+      Failed to detect the installed version of Erlang.
+
+      Use the `mint/install-erlang` leaf to install Erlang and ensure that your task to install Elixir is configured to `use` your Erlang install.
+      EOF
+
         exit 1
       fi
       echo "Downloading Elixir for Erlang version ${erlang_major_version}"

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -20,14 +20,14 @@ tasks:
       echo "Downloading Elixir for Erlang version ${erlang_major_version}"
 
       file="elixir-otp-${erlang_major_version}.zip"
-      mkdir $HOME/elixir
-      cd $HOME/elixir
+      install_dir="/opt/elixir/${ELIXIR_VERSION}"
+      sudo mkdir -p $install_dir
       echo "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/${file}"
       curl -LO "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/${file}"
-      unzip "$file"
+      sudo unzip "$file" -d "$install_dir"
       rm "$file"
-      echo "$HOME/elixir/bin" > $MINT_ENV/PATH
+      echo "${install_dir}/bin" > $MINT_ENV/PATH
 
-      bin/elixir --version
+      $install_dir/bin/elixir --version
     env:
       ELIXIR_VERSION: ${{ params.elixir-version }}

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -22,7 +22,7 @@ tasks:
         cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
       Failed to detect the installed version of Erlang.
 
-      Use the \`mint/install-erlang\` leaf to install Erlang and ensure that your task to install Elixir is configured to \`use\` your Erlang install.
+      Use the [\`mint/install-erlang\` leaf](https://cloud.rwx.com/leaves/mint/install-erlang) to install Erlang and ensure that this task is configured to \`use\` your Erlang install.
       EOF
 
         exit 1

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -22,7 +22,7 @@ tasks:
         cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
       Failed to detect the installed version of Erlang.
 
-      Use the `mint/install-erlang` leaf to install Erlang and ensure that your task to install Elixir is configured to `use` your Erlang install.
+      Use the \`mint/install-erlang\` leaf to install Erlang and ensure that your task to install Elixir is configured to \`use\` your Erlang install.
       EOF
 
         exit 1

--- a/mint/install-elixir/mint-leaf.yml
+++ b/mint/install-elixir/mint-leaf.yml
@@ -12,8 +12,12 @@ parameters:
 tasks:
   - key: install
     run: |
+      set +e
       erlang_major_version=$(erl -eval 'erlang:display(list_to_integer(erlang:system_info(otp_release))), halt().' -noshell | tr -d '\r\n')
-      if [[ $? -ne 0 ]]; then
+      erlang_exit=$?
+      set -e
+
+      if [[ $erlang_exit -ne 0 ]]; then
         echo "failed to determine version of erlang"
         cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
       Failed to detect the installed version of Erlang.


### PR DESCRIPTION
After merging leaf will be available at:

https://cloud.rwx.com/leaves/mint/install-elixir

Example of error if the `mint/install-elixir` task is not configured to `use` and erlang install:

https://cloud.rwx.com/mint/rwx/runs/face251f0668482e837646d9a5d08c8b