### PR TITLE
Ensure full version numbers work when installing chrome

### DIFF
--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 1.0.0
+    call: google/install-chrome 1.0.1
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 1.0.0
+    call: google/install-chrome 1.0.1
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 1.0.0
+    call: google/install-chrome 1.0.1
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 1.0.0
+    call: google/install-chrome 1.0.1
     with:
       chrome-version: 130
       install-chromedriver: true

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -10,6 +10,15 @@
     chrome --version | grep '115\.'
     chromedriver --version | grep '115\.'
 
+- key: test--install-only-chrome--full-version-number
+  call: $LEAF_DIGEST
+  with:
+    chrome-version: 126.0.6478.55
+
+- key: verify--install-only-chrome--full-version-number
+  use: test--install-only-chrome--full-version-number
+  run: chrome --version | grep '126\.0\.6478\.55'
+
 - key: test--install-only-chrome--short-version-number
   call: $LEAF_DIGEST
   with:

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 1.0.0
+version: 1.0.1
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -40,7 +40,7 @@ tasks:
       else
         chromes=$(curl -fsSL https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json)
 
-        if [[ "${CHROME_VERSION}" =~ ^\d+\.\d+\.\d+\.\d+$ ]]; then
+        if [[ "${CHROME_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           chrome=$(echo "${chromes}" | jq --arg version "${CHROME_VERSION}" '[.versions[] | select(.version == $version)] | last')
         else
           chrome=$(echo "${chromes}" | jq --arg version "${CHROME_VERSION}." '[.versions[] | select(.version | startswith($version))] | last')


### PR DESCRIPTION
This missing test was an oversight on my part during the initial implementation and it uncovers a bug with the bash regular expressions (seems like `\d` isn't available!)