### PR TITLE
Ensure Chrome can be used headed and headless

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -6,3 +6,4 @@ words:
   - gcloud
   - setuptools
   - chromedriver
+  - xvfb

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -109,12 +109,11 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
     bundle install
 
     ruby selenium.rb | grep "Hello WebDriver! - Google Search"
-    cat selenium.log
 ```
 
 # Using headed Chrome
 
-You can also use tools that interact with headed Chrome. To do so, you'll need to add a background process to the task that's using Chrome. Here's an example with Selenium and Ruby:
+You can also use tools that interact with headed Chrome. To do so, wrap your command that interacts with Chrome with `xvfb-run`. `google/install-chrome` installs `xvfb` for you. Here's an example with Selenium and Ruby:
 
 ```yml
 - key: chrome
@@ -130,10 +129,6 @@ You can also use tools that interact with headed Chrome. To do so, you'll need t
 
 - key: selenium-example
   use: [chrome, ruby]
-  background-processes:
-    - key: chrome-virtual-display
-      run: start-chrome-virtual-display
-      ready-check: is-chrome-virtual-display-running
   run: |
     cat << EOF > Gemfile
     source "https://rubygems.org"
@@ -162,15 +157,7 @@ You can also use tools that interact with headed Chrome. To do so, you'll need t
 
     bundle install
 
-    ruby selenium.rb | grep "Hello WebDriver! - Google Search"
-    cat selenium.log
+    xvfb-run ruby selenium.rb | grep "Hello WebDriver! - Google Search"
 ```
 
-Take note of the background process that's using `start-chrome-virtual-display` and `is-chrome-virtual-display-running`. These are two additional executables we provide to make headed Chrome usage easier. They are within the `chrome-directory`, so by default they'll be in PATH. These small programs start a virtual display that Chrome can interact with.
-
-`start-chrome-virtual-display` accepts two arguments, optionally:
-
-- `start-chrome-virtual-display 1280x1024` sets the resolution to 1280x1024
-- `start-chrome-virtual-display 1280x1024 24` sets the resolution to 1280x1024 and the bit depth to 24
-
-By default, `start-chrome-virtual-display` will provide a virtual display with a resolution of 1280x1024 and bit depth of 24.
+Even though we make this available, we do recommend using headless mode whenever and wherever possible. `xvfb-run` is known to be flaky.

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 1.1.0
+    call: google/install-chrome 2.0.0
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 1.1.0
+    call: google/install-chrome 2.0.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 1.1.0
+    call: google/install-chrome 2.0.0
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 1.1.0
+    call: google/install-chrome 2.0.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -55,14 +55,6 @@ tasks:
   - key: use-chromes
     use: [chrome-130, chrome-129]
     run: |
-      ${{ tasks.chrome-129.values.chrome-binary }} --version | grep "129\."
-      ${{ tasks.chrome-129.values.chromedriver-binary }} --version | grep "129\."
-
-      ${{ tasks.chrome-130.values.chrome-binary }} --version | grep "130\."
-      ${{ tasks.chrome-130.values.chromedriver-binary }} --version | grep "130\."
-
-      # or...
-
       /opt/chrome-129/chrome --version | grep "129\."
       /opt/chromedriver-129/chromedriver --version | grep "129\."
 
@@ -70,31 +62,19 @@ tasks:
       /opt/chromedriver-130/chromedriver --version | grep "130\."
 ```
 
-The following output values are available:
-
-- `${{ tasks.chrome.values.chrome-version }}`
-- `${{ tasks.chrome.values.chrome-binary }}`
-- `${{ tasks.chrome.values.chrome-directory }}`
-- `${{ tasks.chrome.values.chromedriver-binary }}`
-- `${{ tasks.chrome.values.chromedriver-directory }}`
-- `${{ tasks.chrome.values.start-virtual-display-binary }} `
-- `${{ tasks.chrome.values.is-virtual-display-running-binary }} `
-
-The `chromedriver-*` values are only available when chromedriver is installed.
-
 # Using headless Chrome
 
 By default, `google/install-chrome` supports tools that interact with Chrome in headless mode. Here's an example with Selenium and Ruby:
 
 ```yml
 - key: chrome
-  call: google/install-chrome 1.1.0
+  call: google/install-chrome 2.0.0
   with:
     chrome-version: stable
     install-chromedriver: true
 
 - key: ruby
-  call: mint/install-ruby 1.1.0
+  call: mint/install-ruby 2.0.0
   with:
     ruby-version: 3.3.4
 
@@ -138,13 +118,13 @@ You can also use tools that interact with headed Chrome. To do so, you'll need t
 
 ```yml
 - key: chrome
-  call: google/install-chrome 1.1.0
+  call: google/install-chrome 2.0.0
   with:
     chrome-version: stable
     install-chromedriver: true
 
 - key: ruby
-  call: mint/install-ruby 1.1.0
+  call: mint/install-ruby 2.0.0
   with:
     ruby-version: 3.3.4
 

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -80,11 +80,11 @@ The following output values are available:
 - `${{ tasks.chrome.values.start-virtual-display-binary }} `
 - `${{ tasks.chrome.values.is-virtual-display-running-binary }} `
 
-The `chromedriver-*` values are only available when chromedriver is installed. The `*-virtual-display-*` values are only available when `headless` is false.
+The `chromedriver-*` values are only available when chromedriver is installed.
 
 # Using headless Chrome
 
-By default, `google/install-chrome` is configured with `headless: true`. You'll need to make sure you've configured your tool of choice to run use headless Chrome. Here's an example with Selenium and Ruby:
+By default, `google/install-chrome` supports tools that interact with Chrome in headless mode. Here's an example with Selenium and Ruby:
 
 ```yml
 - key: chrome
@@ -134,7 +134,7 @@ By default, `google/install-chrome` is configured with `headless: true`. You'll 
 
 # Using headed Chrome
 
-You can also use headed Chrome. To do so, you'll need to supply `headless: false` and add a background process to the task that's using Chrome. Here's an example with Selenium and Ruby:
+You can also use tools that interact with headed Chrome. To do so, you'll need to add a background process to the task that's using Chrome. Here's an example with Selenium and Ruby:
 
 ```yml
 - key: chrome
@@ -142,7 +142,6 @@ You can also use headed Chrome. To do so, you'll need to supply `headless: false
   with:
     chrome-version: stable
     install-chromedriver: true
-    headless: false
 
 - key: ruby
   call: mint/install-ruby 1.1.0
@@ -187,7 +186,7 @@ You can also use headed Chrome. To do so, you'll need to supply `headless: false
     cat selenium.log
 ```
 
-You'll see the usage of `start-chrome-virtual-display` and `is-chrome-virtual-display-running`. These are two additional executables we provide when `headless: false` is supplied. They are within the `chrome-directory`, so by default they'll be in PATH. These small programs start a virtual display that Chrome can interact with.
+Take note of the background process that's using `start-chrome-virtual-display` and `is-chrome-virtual-display-running`. These are two additional executables we provide to make headed Chrome usage easier. They are within the `chrome-directory`, so by default they'll be in PATH. These small programs start a virtual display that Chrome can interact with.
 
 `start-chrome-virtual-display` accepts two arguments, optionally:
 

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -86,20 +86,23 @@
   use: test--install-chromedriver
   run: chromedriver --version | grep '129\.'
 
-- key: test--install-ruby
+- key: test--headed-and-headless-chrome-works--install-ruby
   call: mint/install-ruby 1.1.0
   with:
     ruby-version: 3.3.4
 
-- key: test--headed-chrome-works--install-chrome
+- key: test--headed-and-headless-chrome-works--install-chrome
   call: $LEAF_DIGEST
   with:
     chrome-version: stable
     install-chromedriver: true
-    headless: false
 
 - key: verify--headed-chrome-works
-  use: [test--headed-chrome-works--install-chrome, test--install-ruby]
+  use:
+    [
+      test--headed-and-headless-chrome-works--install-chrome,
+      test--headed-and-headless-chrome-works--install-ruby,
+    ]
   background-processes:
     - key: chrome-virtual-display
       run: start-chrome-virtual-display
@@ -135,15 +138,12 @@
     ruby selenium.rb | grep "Hello WebDriver! - Google Search"
     cat selenium.log
 
-- key: test--headless-chrome-works--install-chrome
-  call: $LEAF_DIGEST
-  with:
-    chrome-version: stable
-    install-chromedriver: true
-    headless: true # this is the default, but let's be explicit here for testing purposes
-
 - key: verify--headless-chrome-works
-  use: [test--headless-chrome-works--install-chrome, test--install-ruby]
+  use:
+    [
+      test--headed-and-headless-chrome-works--install-chrome,
+      test--headed-and-headless-chrome-works--install-ruby,
+    ]
   run: |
     cat << EOF > Gemfile
     source "https://rubygems.org"

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -97,10 +97,6 @@
       test--headed-and-headless-chrome-works--install-chrome,
       test--headed-and-headless-chrome-works--install-ruby,
     ]
-  background-processes:
-    - key: chrome-virtual-display
-      run: start-chrome-virtual-display
-      ready-check: is-chrome-virtual-display-running
   run: |
     cat << EOF > Gemfile
     source "https://rubygems.org"
@@ -110,9 +106,6 @@
 
     cat << EOF > selenium.rb
     require "selenium-webdriver"
-
-    Selenium::WebDriver.logger.level = :debug
-    Selenium::WebDriver.logger.output = 'selenium.log'
 
     options = Selenium::WebDriver::Options.chrome(args: [])
     driver = Selenium::WebDriver.for(:chrome, options:)
@@ -129,8 +122,7 @@
 
     bundle install
 
-    ruby selenium.rb | grep "Hello WebDriver! - Google Search"
-    cat selenium.log
+    xvfb-run ruby selenium.rb | grep "Hello WebDriver! - Google Search"
 
 - key: verify--headless-chrome-works
   use:
@@ -148,9 +140,6 @@
     cat << EOF > selenium.rb
     require "selenium-webdriver"
 
-    Selenium::WebDriver.logger.level = :debug
-    Selenium::WebDriver.logger.output = 'selenium.log'
-
     options = Selenium::WebDriver::Options.chrome(args: ['--headless=new'])
     driver = Selenium::WebDriver.for(:chrome, options:)
     driver.navigate.to "http://google.com"
@@ -167,4 +156,3 @@
     bundle install
 
     ruby selenium.rb | grep "Hello WebDriver! - Google Search"
-    cat selenium.log

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -59,12 +59,6 @@
   use:
     [test--install-multiple-chromes--129, test--install-multiple-chromes--130]
   run: |
-    ${{ tasks.test--install-multiple-chromes--129.values.chrome-binary }} --version | grep "129\."
-    ${{ tasks.test--install-multiple-chromes--129.values.chromedriver-binary }} --version | grep "129\."
-
-    ${{ tasks.test--install-multiple-chromes--130.values.chrome-binary }} --version | grep "130\."
-    ${{ tasks.test--install-multiple-chromes--130.values.chromedriver-binary }} --version | grep "130\."
-
     /opt/chrome-129/chrome --version | grep "129\."
     /opt/chromedriver-129/chromedriver --version | grep "129\."
 

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -85,3 +85,92 @@
 - key: verify--install-chromedriver
   use: test--install-chromedriver
   run: chromedriver --version | grep '129\.'
+
+- key: test--install-ruby
+  call: mint/install-ruby 1.1.0
+  with:
+    ruby-version: 3.3.4
+
+- key: test--headed-chrome-works--install-chrome
+  call: $LEAF_DIGEST
+  with:
+    chrome-version: stable
+    install-chromedriver: true
+    headless: false
+
+- key: verify--headed-chrome-works
+  use: [test--headed-chrome-works--install-chrome, test--install-ruby]
+  background-processes:
+    - key: chrome-virtual-display
+      run: start-chrome-virtual-display
+      ready-check: is-chrome-virtual-display-running
+  run: |
+    cat << EOF > Gemfile
+    source "https://rubygems.org"
+
+    gem "selenium-webdriver", "~> 4.24"
+    EOF
+
+    cat << EOF > selenium.rb
+    require "selenium-webdriver"
+
+    Selenium::WebDriver.logger.level = :debug
+    Selenium::WebDriver.logger.output = 'selenium.log'
+
+    options = Selenium::WebDriver::Options.chrome(args: [])
+    driver = Selenium::WebDriver.for(:chrome, options:)
+    driver.navigate.to "http://google.com"
+
+    element = driver.find_element(name: 'q')
+    element.send_keys "Hello WebDriver!"
+    element.submit
+
+    puts driver.title
+
+    driver.quit
+    EOF
+
+    bundle install
+
+    ruby selenium.rb | grep "Hello WebDriver! - Google Search"
+    cat selenium.log
+
+- key: test--headless-chrome-works--install-chrome
+  call: $LEAF_DIGEST
+  with:
+    chrome-version: stable
+    install-chromedriver: true
+    headless: true # this is the default, but let's be explicit here for testing purposes
+
+- key: verify--headless-chrome-works
+  use: [test--headless-chrome-works--install-chrome, test--install-ruby]
+  run: |
+    cat << EOF > Gemfile
+    source "https://rubygems.org"
+
+    gem "selenium-webdriver", "~> 4.24"
+    EOF
+
+    cat << EOF > selenium.rb
+    require "selenium-webdriver"
+
+    Selenium::WebDriver.logger.level = :debug
+    Selenium::WebDriver.logger.output = 'selenium.log'
+
+    options = Selenium::WebDriver::Options.chrome(args: ['--headless=new'])
+    driver = Selenium::WebDriver.for(:chrome, options:)
+    driver.navigate.to "http://google.com"
+
+    element = driver.find_element(name: 'q')
+    element.send_keys "Hello WebDriver!"
+    element.submit
+
+    puts driver.title
+
+    driver.quit
+    EOF
+
+    bundle install
+
+    ruby selenium.rb | grep "Hello WebDriver! - Google Search"
+    cat selenium.log

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -123,7 +123,9 @@ tasks:
       resolution="${1:-1280x1024}"
       bitdepth="${2:-24}"
 
-      sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"
+      if ! sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"; then
+        echo "Xvfb failed to start. Status: $?"
+      fi
       EOF
       sudo chown root:root "${start_virtual_display_binary}"
       sudo chmod 0755 "${start_virtual_display_binary}"

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -112,34 +112,6 @@ tasks:
       # Store useful chrome values
       chrome_binary="${CHROME_DIRECTORY}/chrome"
 
-      # Write virtual display helpers for headed browser usage
-      echo ":99" > "${MINT_ENV}/DISPLAY"
-
-      start_virtual_display_binary="${CHROME_DIRECTORY}/start-chrome-virtual-display"
-      cat << "EOF" > "${start_virtual_display_binary}"
-      #!/usr/bin/env bash
-      set -ueo pipefail
-
-      resolution="${1:-1280x1024}"
-      bitdepth="${2:-24}"
-
-      if ! sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"; then
-        echo "Xvfb failed to start. Status: $?"
-      fi
-      EOF
-      sudo chown root:root "${start_virtual_display_binary}"
-      sudo chmod 0755 "${start_virtual_display_binary}"
-
-      is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
-      cat << "EOF" > "${is_virtual_display_running_binary}"
-      #!/usr/bin/env bash
-      set -ueo pipefail
-
-      xdpyinfo
-      EOF
-      sudo chown root:root "${is_virtual_display_running_binary}"
-      sudo chmod 0755 "${is_virtual_display_running_binary}"
-
       echo "Installed Chrome ${CHROME_VERSION}"
       "${chrome_binary}" --version
       echo

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -123,7 +123,7 @@ tasks:
         echo ":99" > "${MINT_ENV}/DISPLAY"
 
         start_virtual_display_binary="${CHROME_DIRECTORY}/start-chrome-virtual-display"
-        cat << EOF > "${start_virtual_display_binary}"
+        cat << "EOF" > "${start_virtual_display_binary}"
       #!/usr/bin/env bash
       set -ueo pipefail
 
@@ -137,7 +137,7 @@ tasks:
         echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
 
         is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
-        cat << EOF > "${is_virtual_display_running_binary}"
+        cat << "EOF" > "${is_virtual_display_running_binary}"
       #!/usr/bin/env bash
       set -ueo pipefail
 

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 1.1.0
+version: 2.0.0
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -111,8 +111,6 @@ tasks:
 
       # Store useful chrome values
       chrome_binary="${CHROME_DIRECTORY}/chrome"
-      echo "${CHROME_DIRECTORY}" > "${MINT_VALUES}/chrome-directory"
-      echo "${chrome_binary}" > "${MINT_VALUES}/chrome-binary"
 
       # Write virtual display helpers for headed browser usage
       echo ":99" > "${MINT_ENV}/DISPLAY"
@@ -129,7 +127,6 @@ tasks:
       EOF
       sudo chown root:root "${start_virtual_display_binary}"
       sudo chmod 0755 "${start_virtual_display_binary}"
-      echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
 
       is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
       cat << "EOF" > "${is_virtual_display_running_binary}"
@@ -140,7 +137,6 @@ tasks:
       EOF
       sudo chown root:root "${is_virtual_display_running_binary}"
       sudo chmod 0755 "${is_virtual_display_running_binary}"
-      echo "${is_virtual_display_running_binary}" > "${MINT_VALUES}/is-virtual-display-running-binary"
 
       echo "Installed Chrome ${CHROME_VERSION}"
       "${chrome_binary}" --version
@@ -158,8 +154,6 @@ tasks:
         unzip chromedriver.zip
         sudo mv chromedriver-linux64 "${CHROMEDRIVER_DIRECTORY}"
         chromedriver_binary="${CHROMEDRIVER_DIRECTORY}/chromedriver"
-        echo "${CHROMEDRIVER_DIRECTORY}" > "${MINT_VALUES}/chromedriver-directory"
-        echo "${chromedriver_binary}" > "${MINT_VALUES}/chromedriver-binary"
 
         echo "Installed Chromedriver for Chrome ${CHROME_VERSION}"
         "${chromedriver_binary}" --version

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -8,10 +8,6 @@ parameters:
   chrome-version:
     description: "Version of Chrome to install."
     required: true
-  headless:
-    description: "Whether Chrome will be used in a headless environment."
-    required: false
-    default: true
   install-chromedriver:
     description: "Whether a compatible Chromedriver should be installed."
     required: false
@@ -118,12 +114,11 @@ tasks:
       echo "${CHROME_DIRECTORY}" > "${MINT_VALUES}/chrome-directory"
       echo "${chrome_binary}" > "${MINT_VALUES}/chrome-binary"
 
-      # Write virtual display helper for headed browser usage
-      if [[ "${HEADED}" == "true" ]]; then
-        echo ":99" > "${MINT_ENV}/DISPLAY"
+      # Write virtual display helpers for headed browser usage
+      echo ":99" > "${MINT_ENV}/DISPLAY"
 
-        start_virtual_display_binary="${CHROME_DIRECTORY}/start-chrome-virtual-display"
-        cat << "EOF" > "${start_virtual_display_binary}"
+      start_virtual_display_binary="${CHROME_DIRECTORY}/start-chrome-virtual-display"
+      cat << "EOF" > "${start_virtual_display_binary}"
       #!/usr/bin/env bash
       set -ueo pipefail
 
@@ -132,21 +127,20 @@ tasks:
 
       sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"
       EOF
-        sudo chown root:root "${start_virtual_display_binary}"
-        sudo chmod 0755 "${start_virtual_display_binary}"
-        echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
+      sudo chown root:root "${start_virtual_display_binary}"
+      sudo chmod 0755 "${start_virtual_display_binary}"
+      echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
 
-        is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
-        cat << "EOF" > "${is_virtual_display_running_binary}"
+      is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
+      cat << "EOF" > "${is_virtual_display_running_binary}"
       #!/usr/bin/env bash
       set -ueo pipefail
 
       xdpyinfo
       EOF
-        sudo chown root:root "${is_virtual_display_running_binary}"
-        sudo chmod 0755 "${is_virtual_display_running_binary}"
-        echo "${is_virtual_display_running_binary}" > "${MINT_VALUES}/is-virtual-display-running-binary"
-      fi
+      sudo chown root:root "${is_virtual_display_running_binary}"
+      sudo chmod 0755 "${is_virtual_display_running_binary}"
+      echo "${is_virtual_display_running_binary}" > "${MINT_VALUES}/is-virtual-display-running-binary"
 
       echo "Installed Chrome ${CHROME_VERSION}"
       "${chrome_binary}" --version
@@ -191,4 +185,3 @@ tasks:
       CHROMEDRIVER_DIRECTORY: ${{ params.chromedriver-directory }}
       CHROMEDRIVER_DOWNLOAD_URL: ${{ tasks.resolve-chrome-version.values.chromedriver-download-url }}
       INSTALL_CHROMEDRIVER: ${{ params.install-chromedriver }}
-      HEADED: ${{ params.headless != true }}

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,27 +1,31 @@
 name: google/install-chrome
-version: 1.0.1
+version: 1.1.0
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
 
 parameters:
   chrome-version:
-    description: "Version of chrome to install."
+    description: "Version of Chrome to install."
     required: true
+  headless:
+    description: "Whether Chrome will be used in a headless environment."
+    required: false
+    default: true
   install-chromedriver:
-    description: "Whether a compatible chromedriver should be installed."
+    description: "Whether a compatible Chromedriver should be installed."
     required: false
     default: false
   chrome-directory:
-    description: "The directory where chrome will be installed."
+    description: "The directory where Chrome will be installed."
     required: false
     default: /opt/chrome
   chromedriver-directory:
-    description: "The directory where chromedriver will be installed."
+    description: "The directory where Chromedriver will be installed."
     required: false
     default: /opt/chromedriver
   add-to-path:
-    description: "Whether chrome and (optionally) chromedriver should be included in PATH."
+    description: "Whether Chrome and (optionally) Chromedriver should be included in PATH."
     required: false
     default: true
 
@@ -88,7 +92,8 @@ tasks:
         xvfb \
         fonts-liberation \
         libu2f-udev \
-        xdg-utils
+        xdg-utils \
+        x11-utils
       sudo apt-get clean
 
       path_additions=""
@@ -97,14 +102,53 @@ tasks:
       echo "Installing Chrome ${CHROME_VERSION}"
       echo
 
+      # Unpack chrome into the chrome directory
       curl -fsSL "${CHROME_DOWNLOAD_URL}" -o chrome.zip
       unzip chrome.zip
       sudo mv chrome-linux64 "${CHROME_DIRECTORY}"
+
+      # Set the correct permissions on the sandbox binary
+      chrome_sandbox_binary="${CHROME_DIRECTORY}/chrome_sandbox"
+      sudo chown root:root "${chrome_sandbox_binary}"
+      sudo chmod 4755 "${chrome_sandbox_binary}"
+      echo "${chrome_sandbox_binary}" > "${MINT_ENV}/CHROME_DEVEL_SANDBOX"
+
+      # Store useful chrome values
       chrome_binary="${CHROME_DIRECTORY}/chrome"
       echo "${CHROME_DIRECTORY}" > "${MINT_VALUES}/chrome-directory"
       echo "${chrome_binary}" > "${MINT_VALUES}/chrome-binary"
 
-      echo "Installing Chrome ${CHROME_VERSION}"
+      # Write virtual display helper for headed browser usage
+      if [[ "${HEADED}" == "true" ]]; then
+        echo ":99" > "${MINT_ENV}/DISPLAY"
+
+        start_virtual_display_binary="${CHROME_DIRECTORY}/start-chrome-virtual-display"
+        cat << EOF > "${start_virtual_display_binary}"
+      #!/usr/bin/env bash
+      set -ueo pipefail
+
+      resolution="${1:-1280x1024}"
+      bitdepth="${2:-24}"
+
+      sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"
+        EOF
+        sudo chown root:root "${start_virtual_display_binary}"
+        sudo chmod 0755 "${start_virtual_display_binary}"
+        echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
+
+        is_virtual_display_running_binary="${CHROME_DIRECTORY}/is-chrome-virtual-display-running"
+        cat << EOF > "${is_virtual_display_running_binary}"
+      #!/usr/bin/env bash
+      set -ueo pipefail
+
+      xdpyinfo
+        EOF
+        sudo chown root:root "${is_virtual_display_running_binary}"
+        sudo chmod 0755 "${is_virtual_display_running_binary}"
+        echo "${is_virtual_display_running_binary}" > "${MINT_VALUES}/is-virtual-display-running-binary"
+      fi
+
+      echo "Installed Chrome ${CHROME_VERSION}"
       "${chrome_binary}" --version
       echo
 
@@ -123,7 +167,7 @@ tasks:
         echo "${CHROMEDRIVER_DIRECTORY}" > "${MINT_VALUES}/chromedriver-directory"
         echo "${chromedriver_binary}" > "${MINT_VALUES}/chromedriver-binary"
 
-        echo "Installing Chromedriver for Chrome ${CHROME_VERSION}"
+        echo "Installed Chromedriver for Chrome ${CHROME_VERSION}"
         "${chromedriver_binary}" --version
         echo
 
@@ -147,3 +191,4 @@ tasks:
       CHROMEDRIVER_DIRECTORY: ${{ params.chromedriver-directory }}
       CHROMEDRIVER_DOWNLOAD_URL: ${{ tasks.resolve-chrome-version.values.chromedriver-download-url }}
       INSTALL_CHROMEDRIVER: ${{ params.install-chromedriver }}
+      HEADED: ${{ params.headless != true }}

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -131,7 +131,7 @@ tasks:
       bitdepth="${2:-24}"
 
       sudo Xvfb "${DISPLAY}" -screen 0 "${resolution}x${bitdepth}"
-        EOF
+      EOF
         sudo chown root:root "${start_virtual_display_binary}"
         sudo chmod 0755 "${start_virtual_display_binary}"
         echo "${start_virtual_display_binary}" > "${MINT_VALUES}/start-virtual-display-binary"
@@ -142,7 +142,7 @@ tasks:
       set -ueo pipefail
 
       xdpyinfo
-        EOF
+      EOF
         sudo chown root:root "${is_virtual_display_running_binary}"
         sudo chmod 0755 "${is_virtual_display_running_binary}"
         echo "${is_virtual_display_running_binary}" > "${MINT_VALUES}/is-virtual-display-running-binary"


### PR DESCRIPTION
While using `google/install-chrome` I ran into a few issues.

First, running `chrome` without `--no-sandbox` was crashing because the `chrome_sandbox` binary did not have the proper permissions and ownership. This PR fixes that.

Second, running `chrome` headed was not working because the task using Chrome did not properly configure a virtual display. This PR adds some docs around using `xvfb-run` to use Chrome in that manner.