### PR TITLE
[rwx/install-abq] Make RWX_ACCESS_TOKEN optional

### DIFF
--- a/.mint/build-tasks.mjs
+++ b/.mint/build-tasks.mjs
@@ -94,7 +94,7 @@ const generateLeafRun = (leaf) => {
       {
         key: "build",
         use: ["packages", "code"],
-        filter: [`${leaf.dir}/**/*`],
+        filter: [leaf.dir],
         run: `
           timestamp="\${{ tasks.timestamp.values.timestamp }}"
           echo "Setting timestamp on files to $timestamp"

--- a/.mint/ci.yml
+++ b/.mint/ci.yml
@@ -71,8 +71,8 @@ tasks:
         fi
       done <<< "$leaves"
     filter:
-      - README.md
-      - mint-leaf.yml
+      - "**/README.md"
+      - "**/mint-leaf.yml"
 
   - key: build-leaf-runs
     use: npm-install

--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,21 +7,9 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.0.2
-    with:
-      rwx-access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
+    call: rwx/install-abq 1.1.0
 ```
 
-You will need to have an `RWX_ACCESS_TOKEN` set in your vault.
-
-Generate access tokens at:
-
-https://cloud.rwx.com/org/deep_link/manage/access_tokens
-
-And access your vaults at:
-
-https://cloud.rwx.com/mint/deep_link/vaults
-
-ABQ Documentation:
+### ABQ Documentation:
 
 https://www.rwx.com/docs/abq

--- a/rwx/install-abq/mint-ci-cd.template.yml
+++ b/rwx/install-abq/mint-ci-cd.template.yml
@@ -1,8 +1,15 @@
 - key: install-abq--test-default
   call: $LEAF_DIGEST
-  with:
-    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
 
 - key: install-abq--test-default--assert
   use: install-abq--test-default
+  run: abq --version | grep '^abq 1\.'
+
+- key: install-abq--test-with-token
+  call: $LEAF_DIGEST
+  with:
+    rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
+
+- key: install-abq--test-with-token--assert
+  use: install-abq--test-with-token
   run: abq --version | grep '^abq 1\.'

--- a/rwx/install-abq/mint-leaf.yml
+++ b/rwx/install-abq/mint-leaf.yml
@@ -1,17 +1,20 @@
 name: rwx/install-abq
-version: 1.0.2
+version: 1.1.0
 description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/rwx/install-abq
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
 
 parameters:
   rwx-access-token:
-    description: 'RWX_ACCESS_TOKEN used to authenticate into ABQ'
-    required: true
+    description: "RWX_ACCESS_TOKEN used to authenticate into ABQ. If not specified, the Mint default RWX_ACCESS_TOKEN for your organization is used."
+    required: false
 
 tasks:
   - key: install
     run: |
+      if [[ "${{ params.rwx-access-token }}" != "" ]]; then
+        export RWX_ACCESS_TOKEN=${{ params.rwx-access-token }}
+      fi
       tmp="$(mktemp -d)/abq"
       curl -o $tmp -fsSL \
         -H "Authorization: Bearer $RWX_ACCESS_TOKEN" \
@@ -19,5 +22,3 @@ tasks:
       sudo install $tmp /usr/local/bin
       rm $tmp
       abq --version
-    env:
-      RWX_ACCESS_TOKEN: ${{ params.rwx-access-token }}


### PR DESCRIPTION
Now that we have the default RWX_ACCESS_TOKEN in the environment, we can make this optional.