### PR TITLE
Add a leaf to install the azure CLI

### DIFF
--- a/azure/install-cli/README.md
+++ b/azure/install-cli/README.md
@@ -1,0 +1,23 @@
+# azure/install-cli
+
+To install the latest version of the Azure CLI:
+
+```yaml
+tasks:
+  - key: azure-cli
+    call: azure/install-cli 1.0.0
+```
+
+To install a specific version of the Azure CLI:
+
+```yaml
+tasks:
+  - key: azure-cli
+    call: azure/install-cli 1.0.0
+    with:
+      version: "2.65.0"
+```
+
+For the list of available versions, see the Azure CLI release notes:
+
+https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli

--- a/azure/install-cli/mint-ci-cd.template.yml
+++ b/azure/install-cli/mint-ci-cd.template.yml
@@ -1,0 +1,15 @@
+- key: test-default
+  call: $LEAF_DIGEST
+
+- key: test-default--assert
+  use: test-default
+  run: az version | jq -r '."azure-cli"' | grep '^[0-9.]\+$'
+
+- key: test-specified
+  call: $LEAF_DIGEST
+  with:
+    version: "2.64.0"
+
+- key: test-specified--assert
+  use: test-specified
+  run: az version | jq -e '."azure-cli" == "2.64.0"'

--- a/azure/install-cli/mint-leaf.yml
+++ b/azure/install-cli/mint-leaf.yml
@@ -1,0 +1,73 @@
+name: azure/install-cli
+version: 1.0.0
+description: Install the Azure CLI
+source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/azure/install-cli
+issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
+
+parameters:
+  version:
+    description: "Version of the CLI to install"
+    default: "latest"
+
+tasks:
+  - key: install-cli
+    run: |
+      # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
+
+      echo "Installing dependencies"
+      echo ""
+
+      # Install required deps
+      sudo apt-get update
+      sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
+      sudo apt-get clean
+
+      # Add MSFT keyring
+      sudo mkdir -p /etc/apt/keyrings
+      curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+        gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+      sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+      # Add apt source
+      AZ_DIST=$(lsb_release -cs)
+      echo "Types: deb
+      URIs: https://packages.microsoft.com/repos/azure-cli/
+      Suites: ${AZ_DIST}
+      Components: main
+      Architectures: $(dpkg --print-architecture)
+      Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+
+      # Fetch from apt source
+      sudo apt-get update
+
+      # Find known versions
+      dist=$(lsb_release -cs)
+      versions=$(apt-cache show azure-cli | grep "Version: " | sed 's/Version: //' | sed "s/-1~${dist}//")
+
+      version=""
+      if [[ "${VERSION}" == "latest" ]]; then
+        version=$(echo "${versions}" | head -n 1)
+      else
+        version=$(echo "${versions}" | { grep "${VERSION}" || test $? = 1; })
+        if [[ -z "${version}" ]]; then
+          cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
+      Azure CLI version \`${VERSION}\` is not available. Choose one of:
+
+      \`\`\`
+      ${versions}
+      \`\`\`
+      EOF
+          exit 1
+        fi
+      fi
+
+      echo ""
+      echo "Installing Azure CLI v${version}"
+      echo ""
+      sudo apt-get install azure-cli=${version}-1~${dist}
+
+      echo ""
+      echo "Installed Azure CLI:"
+      az version
+    env:
+      VERSION: ${{ params.version }}


### PR DESCRIPTION
Follows the instructions in https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions to install the Azure CLI.

Not all versions are available via apt. I suspect it's mostly due to how long the ubuntu release has been around since it's pinned to the dist (we have versions going back to ~2022)

This error is provided when you pass an unsupported version: ![CleanShot 2024-10-17 at 11 41 45@2x](https://github.com/user-attachments/assets/cde9e66e-16b5-420d-95d8-804cb107853a)