### PR TITLE
Cache LFS files separately when cloning

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.8
+    call: mint/git-clone 1.3.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.8
+    call: mint/git-clone 1.3.0
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.8
+    call: mint/git-clone 1.3.0
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.2.8
+    call: mint/git-clone 1.3.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -2,7 +2,7 @@
   call: $LEAF_DIGEST
   with:
     repository: git@github.com:rwx-research/test-checkout-leaf.git
-    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
 
 - key: git-clone--test-ssh-key--assert
@@ -13,7 +13,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
     github-access-token: ${{ github.token }}
 
 - key: git-clone--test-github-access-token--assert
@@ -49,7 +49,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
     github-access-token: ${{ github.token }}
     preserve-git-dir: true
 
@@ -71,7 +71,7 @@
   call: $LEAF_DIGEST
   with:
     repository: git@github.com:rwx-research/test-checkout-leaf.git
-    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
 
 - key: git-clone--test-commit-sha-ref-meta--assert
@@ -234,7 +234,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: fe9898728c9442ee39df04e046b6010cb950b303
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
     github-access-token: ${{ github.token }}
     preserve-git-dir: true
     path: mint-leaves
@@ -253,3 +253,58 @@
     test $GIT_USERNAME = "rwx-mint[bot]"
   env:
     GITHUB_TOKEN: ${{ github.token }}
+
+- key: git-clone--test-lfs-with-github-token
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    github-access-token: ${{ github.token }}
+    lfs: true
+
+- key: git-clone--test-lfs-with-github-token--assert
+  use: git-clone--test-lfs-with-github-token
+  run: |
+    grep -q "lfs file" lfs-file.txt
+
+- key: git-clone--test-lfs-with-ssh-key
+  call: $LEAF_DIGEST
+  with:
+    repository: git@github.com:rwx-research/test-checkout-leaf.git
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    lfs: true
+
+- key: git-clone--test-lfs-with-ssh-key--assert
+  use: git-clone--test-lfs-with-ssh-key
+  run: |
+    grep -q "lfs file" lfs-file.txt
+
+- key: git-clone--test-lfs-with-preserve-data
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    github-access-token: ${{ github.token }}
+    lfs: true
+    preserve-git-dir: true
+
+- key: git-clone--test-lfs-with-preserve-data--assert
+  use: git-clone--test-lfs-with-preserve-data
+  run: |
+    grep -q "lfs file" lfs-file.txt
+    git status | grep -q "nothing to commit, working tree clean"
+
+- key: git-clone--test-lfs-with-path
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    github-access-token: ${{ github.token }}
+    lfs: true
+    path: mint-leaves
+
+- key: git-clone--test-lfs-with-path--assert
+  use: git-clone--test-lfs-with-path
+  run: |
+    grep -q "lfs file" mint-leaves/lfs-file.txt

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.2.8
+version: 1.3.0
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -127,8 +127,58 @@ tasks:
       echo "Checked out git repository at ${commit_sha}"
 
       if [[ "${LFS}" == "true" ]]; then
-        git lfs fetch
-        git lfs checkout
+        if [[ -z "$GITHUB_TOKEN" ]]; then
+          git lfs fetch
+          git lfs checkout
+        else
+          LFS_FILES=$(git-lfs ls-files -n)
+          if [[ "${LFS_FILES}" != "" ]]; then
+            FILTER_PATH_PREFIX="${CHECKOUT_PATH%/}/"
+            FILTER_LINES=$(echo "$LFS_FILES" | jq -c --raw-input --slurp --arg prefix "$FILTER_PATH_PREFIX" 'split("\n") | map(select(. != "") | $prefix + .)')
+
+            cat << EOF > $MINT_DYNAMIC_TASKS/lfs.yml
+      - key: lfs-files
+        use: configure-git
+        run: |
+          cd "\${CHECKOUT_PATH}"
+          LFS_FILES_ARRAY=(\$LFS_FILES)
+
+          for file in \${LFS_FILES_ARRAY[@]}; do
+            while read -r line; do
+              case \$line in
+                version*) VERSION=\$(echo \$line | awk '{print \$2}') ;;
+                oid*) SHA256=\$(echo \$line | awk '{print \$2}' | cut -d ':' -f 2) ;;
+                size*) SIZE=\$(echo \$line | awk '{print \$2}') ;;
+              esac
+            done < \$file
+
+            DOWNLOAD_URL=\$(curl -X POST \\
+              -H "Accept: application/vnd.git-lfs+json" \\
+              -H "Content-Type: application/json" \\
+              -H "Authorization: Bearer \$GITHUB_TOKEN" \\
+              -d "{\\"operation\\": \\"download\\", \\"transfer\\": [\\"basic\\"], \\"objects\\": [{\\"oid\\": \\"\$SHA256\\", \\"size\\": \$SIZE}]}" \
+              https://github.com/\$MINT_GIT_REPOSITORY_NAME.git/info/lfs/objects/batch | jq -r '.objects[0].actions.download.href')
+
+            curl -o "\$file" "\$DOWNLOAD_URL"
+          done
+        env:
+          GITHUB_TOKEN:
+            value: \\\${{ params.github-access-token }}
+            cache-key: excluded
+          LFS_FILES: $LFS_FILES
+          CHECKOUT_PATH: \\\${{ params.path }}
+          PRESERVE_GIT_DIR: \\\${{ params.preserve-git-dir }}
+        filter: ${FILTER_LINES}
+      EOF
+            if [[ "${PRESERVE_GIT_DIR}" == "true" ]]; then
+              cat << EOF > $MINT_DYNAMIC_TASKS/lfs-cleanup.yml
+      - key: lfs-cleanup
+        use: lfs-files
+        run: git add -Av
+      EOF
+            fi
+          fi
+        fi
       fi
 
       # Set metadata
@@ -180,6 +230,7 @@ tasks:
         rm -rf .git
       fi
     env:
+      GIT_LFS_SKIP_SMUDGE: 1
       CACHE_BUST: ${{ tasks.get-latest-sha-for-ref.values.latest-sha-cache-buster }}
       GIT_SSH_KEY:
         value: ${{ params.ssh-key }}

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -132,6 +132,7 @@ tasks:
           FILTER_PATH_PREFIX="${CHECKOUT_PATH%/}/"
           FILTER_LINES=$(echo "$LFS_FILES" | jq -c --raw-input --slurp --arg prefix "$FILTER_PATH_PREFIX" 'split("\n") | map(select(. != "") | $prefix + .)')
 
+          LFS_ENDPOINT=$(git-lfs env | grep "Endpoint=" | awk -F'[ =]' '{print $2}')
           cat << EOF > $MINT_DYNAMIC_TASKS/lfs.yml
       - key: lfs-files
         use: configure-git
@@ -171,7 +172,7 @@ tasks:
             for header in "\${DOWNLOAD_HEADERS[@]}"; do
               CURL_COMMAND+=" -H \\"\$header\\""
             done
-            URL="https://github.com/\$MINT_GIT_REPOSITORY_NAME.git/info/lfs/objects/batch"
+            URL="$LFS_ENDPOINT/objects/batch"
             DATA="{\\"operation\\": \\"download\\", \\"transfer\\": [\\"basic\\"], \\"objects\\": [{\\"oid\\": \\"\$SHA256\\", \\"size\\": \$SIZE}]}"
             CURL_COMMAND+=" -d '\$DATA' \$URL"
 

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -127,20 +127,35 @@ tasks:
       echo "Checked out git repository at ${commit_sha}"
 
       if [[ "${LFS}" == "true" ]]; then
-        if [[ -z "$GITHUB_TOKEN" ]]; then
-          git lfs fetch
-          git lfs checkout
-        else
-          LFS_FILES=$(git-lfs ls-files -n)
-          if [[ "${LFS_FILES}" != "" ]]; then
-            FILTER_PATH_PREFIX="${CHECKOUT_PATH%/}/"
-            FILTER_LINES=$(echo "$LFS_FILES" | jq -c --raw-input --slurp --arg prefix "$FILTER_PATH_PREFIX" 'split("\n") | map(select(. != "") | $prefix + .)')
+        LFS_FILES=$(git-lfs ls-files -n)
+        if [[ "${LFS_FILES}" != "" ]]; then
+          FILTER_PATH_PREFIX="${CHECKOUT_PATH%/}/"
+          FILTER_LINES=$(echo "$LFS_FILES" | jq -c --raw-input --slurp --arg prefix "$FILTER_PATH_PREFIX" 'split("\n") | map(select(. != "") | $prefix + .)')
 
-            cat << EOF > $MINT_DYNAMIC_TASKS/lfs.yml
+          cat << EOF > $MINT_DYNAMIC_TASKS/lfs.yml
       - key: lfs-files
         use: configure-git
         run: |
           cd "\${CHECKOUT_PATH}"
+
+          DOWNLOAD_HEADERS=(
+            "Accept: application/vnd.git-lfs+json"
+            "Content-Type: application/json"
+          )
+
+          if [[ -n "\$GIT_SSH_KEY" ]]; then
+            SSH_PART=\$(echo "\$CHECKOUT_REPOSITORY" | sed 's/:.*//')
+            REPO_PART=\$(echo "\$CHECKOUT_REPOSITORY" | sed 's/.*://')
+
+            SSH_CREDENTIALS=\$(git-ssh-command \$SSH_PART git-lfs-authenticate \$REPO_PART download)
+            DYNAMIC_HEADERS=\$(echo "\$SSH_CREDENTIALS" | jq -r '.header | to_entries | .[] | "\\(.key): \\(.value)"')
+            while read -r header; do
+              DOWNLOAD_HEADERS+=("\$header")
+            done <<< "\$DYNAMIC_HEADERS"
+          else
+            DOWNLOAD_HEADERS+=("Authorization: Bearer \$GITHUB_TOKEN")
+          fi
+
           LFS_FILES_ARRAY=(\$LFS_FILES)
 
           for file in \${LFS_FILES_ARRAY[@]}; do
@@ -152,16 +167,23 @@ tasks:
               esac
             done < \$file
 
-            DOWNLOAD_URL=\$(curl -X POST \\
-              -H "Accept: application/vnd.git-lfs+json" \\
-              -H "Content-Type: application/json" \\
-              -H "Authorization: Bearer \$GITHUB_TOKEN" \\
-              -d "{\\"operation\\": \\"download\\", \\"transfer\\": [\\"basic\\"], \\"objects\\": [{\\"oid\\": \\"\$SHA256\\", \\"size\\": \$SIZE}]}" \
-              https://github.com/\$MINT_GIT_REPOSITORY_NAME.git/info/lfs/objects/batch | jq -r '.objects[0].actions.download.href')
+            CURL_COMMAND="curl -X POST"
+            for header in "\${DOWNLOAD_HEADERS[@]}"; do
+              CURL_COMMAND+=" -H \\"\$header\\""
+            done
+            URL="https://github.com/\$MINT_GIT_REPOSITORY_NAME.git/info/lfs/objects/batch"
+            DATA="{\\"operation\\": \\"download\\", \\"transfer\\": [\\"basic\\"], \\"objects\\": [{\\"oid\\": \\"\$SHA256\\", \\"size\\": \$SIZE}]}"
+            CURL_COMMAND+=" -d '\$DATA' \$URL"
+
+            DOWNLOAD_URL=\$(eval "\$CURL_COMMAND" | jq -r '.objects[0].actions.download.href')
 
             curl -o "\$file" "\$DOWNLOAD_URL"
           done
         env:
+          CHECKOUT_REPOSITORY: \\\${{ params.repository }}
+          GIT_SSH_KEY:
+            value: \\\${{ params.ssh-key }}
+            cache-key: excluded
           GITHUB_TOKEN:
             value: \\\${{ params.github-access-token }}
             cache-key: excluded
@@ -176,7 +198,6 @@ tasks:
         use: lfs-files
         run: git add -Av
       EOF
-            fi
           fi
         fi
       fi


### PR DESCRIPTION
Previously, we were pulling in LFS files as part of the same task that cloned the repo. This has some unideal characteristics -- LFS files may change very infrequently, and bandwidth costs for pulling LFS files can be really high, plus it can be somewhat slow to pull them in. By pulling them in an independent filtered task, we can cache the files in a Mint layer so long as they don't change.

The general strategy here is to use `git-lfs ls-files` to find all the LFS files in the repo, and then manually download each file into the appropriate location in a task that is filtered to just the LFS files.