### PR TITLE
Fixes cloning multiple LFS files

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.3.0
+    call: mint/git-clone 1.3.1
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.3.0
+    call: mint/git-clone 1.3.1
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.3.0
+    call: mint/git-clone 1.3.1
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.3.0
+    call: mint/git-clone 1.3.1
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.3.0
+version: 1.3.1
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -129,6 +129,7 @@ tasks:
       if [[ "${LFS}" == "true" ]]; then
         LFS_FILES=$(git-lfs ls-files -n)
         if [[ "${LFS_FILES}" != "" ]]; then
+          echo $LFS_FILES > $MINT_VALUES/lfs-files
           FILTER_PATH_PREFIX="${CHECKOUT_PATH%/}/"
           FILTER_LINES=$(echo "$LFS_FILES" | jq -c --raw-input --slurp --arg prefix "$FILTER_PATH_PREFIX" 'split("\n") | map(select(. != "") | $prefix + .)')
 
@@ -188,7 +189,7 @@ tasks:
           GITHUB_TOKEN:
             value: \\\${{ params.github-access-token }}
             cache-key: excluded
-          LFS_FILES: $LFS_FILES
+          LFS_FILES: \\\${{ tasks.git-clone.values.lfs-files }}
           CHECKOUT_PATH: \\\${{ params.path }}
           PRESERVE_GIT_DIR: \\\${{ params.preserve-git-dir }}
         filter: ${FILTER_LINES}


### PR DESCRIPTION
This wasn't working when you had multiple LFS files because we were interpolating the LFS files list directly into the dynamic task -- now we pass it through a value which fixes the syntax issue.