### PR TITLE
[mint/git-clone] Adds an option to clone with a full depth fetch

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.4.0
+    call: mint/git-clone 1.5.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.4.0
+    call: mint/git-clone 1.5.0
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.4.0
+    call: mint/git-clone 1.5.0
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.4.0
+    call: mint/git-clone 1.5.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/bin/git-clone
+++ b/mint/git-clone/bin/git-clone
@@ -4,7 +4,7 @@ set -ueo pipefail
 mkdir -p "${CHECKOUT_PATH}"
 cd "${CHECKOUT_PATH}"
 
-if [[ "${PRESERVE_GIT_DIR}" == "true" ]]; then
+if [[ "${PRESERVE_GIT_DIR}" == "true" || "${FETCH_FULL_DEPTH}"  == "true" ]]; then
   CREDENTIAL_ARG=""
   if [[ "${CREDENTIAL_HELPER}" != "" ]]; then
     CREDENTIAL_ARG="-c credential.helper='${CREDENTIAL_HELPER}'"

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -308,3 +308,15 @@
   use: git-clone--test-lfs-with-path
   run: |
     grep -q "lfs file" mint-leaves/lfs-file.txt
+
+- key: git-clone--test-fetch-full-depth
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    github-access-token: ${{ github.token }}
+    fetch-full-depth: true
+
+- key: git-clone--test-fetch-full-depth--assert
+  use: git-clone--test-fetch-full-depth
+  run: test -e file-in-repo.txt

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.4.0
+version: 1.5.0
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -29,6 +29,9 @@ parameters:
   ssh-key:
     description: "The ssh key to use if cloning over ssh"
     required: false
+  fetch-full-depth:
+    description: "Whether to use a shallow fetch or a full-depth fetch when the repository is cloned and when not preserving the git directory (when `preserve-git-dir` is true, this parameter has no effect). Typically, setting this to `false` (the default) will result in better cloning performance within Mint. However, for certain large repositories, a full depth fetch may be faster."
+    default: false
 
 tasks:
   - key: setup
@@ -140,6 +143,7 @@ tasks:
       LFS: ${{ params.lfs }}
       PRESERVE_GIT_DIR: ${{ params.preserve-git-dir }}
       CREDENTIAL_HELPER: ${{ tasks.setup.values.credential-helper }}
+      FETCH_FULL_DEPTH: ${{ params.fetch-full-depth }}
 
   - key: configure-git
     use: [git-clone]


### PR DESCRIPTION
Typically, a shallow clone is better when you are not preserving the git dir because there is significantly less data to download. We've seen some cases where a full depth fetch performs significantly better, however. In one case a multi-gigabyte repository took ~3 minutes to fetch with a shallow fetch and half the time to fetch full depth.