### PR TITLE
Add an alias for google-chrome

### DIFF
--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.2
+    call: google/install-chrome 2.0.3
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.2
+    call: google/install-chrome 2.0.3
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.0.2
+    call: google/install-chrome 2.0.3
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.0.2
+    call: google/install-chrome 2.0.3
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.2
+  call: google/install-chrome 2.0.3
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.2
+  call: google/install-chrome 2.0.3
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -8,6 +8,7 @@
   use: test--install-oldest-chrome
   run: |
     chrome --version | grep '115\.'
+    google-chrome --version | grep '115\.'
     chromedriver --version | grep '115\.'
 
 - key: test--install-only-chrome--full-version-number
@@ -17,7 +18,9 @@
 
 - key: verify--install-only-chrome--full-version-number
   use: test--install-only-chrome--full-version-number
-  run: chrome --version | grep '126\.0\.6478\.55'
+  run: |
+    chrome --version | grep '126\.0\.6478\.55'
+    google-chrome --version | grep '126\.0\.6478\.55'
 
 - key: test--install-only-chrome--short-version-number
   call: $LEAF_DIGEST
@@ -26,7 +29,9 @@
 
 - key: verify--install-only-chrome--short-version-number
   use: test--install-only-chrome--short-version-number
-  run: chrome --version | grep '129\.'
+  run: |
+    chrome --version | grep '129\.'
+    google-chrome --version | grep '129\.'
 
 - key: test--install-only-chrome--stable-version-number
   call: $LEAF_DIGEST
@@ -35,7 +40,9 @@
 
 - key: verify--install-only-chrome--stable-version-number
   use: test--install-only-chrome--stable-version-number
-  run: chrome --version | grep "${{ tasks.test--install-only-chrome--stable-version-number.values.chrome-version }}"
+  run: |
+    chrome --version | grep "${{ tasks.test--install-only-chrome--stable-version-number.values.chrome-version }}"
+    google-chrome --version | grep "${{ tasks.test--install-only-chrome--stable-version-number.values.chrome-version }}"
 
 - key: test--install-multiple-chromes--129
   call: $LEAF_DIGEST
@@ -56,17 +63,23 @@
     add-to-path: false
 
 - key: verify--install-multiple-chromes
-  use:
-    [test--install-multiple-chromes--129, test--install-multiple-chromes--130]
+  use: [test--install-multiple-chromes--129, test--install-multiple-chromes--130]
   run: |
     /opt/chrome-129/chrome --version | grep "129\."
+    /opt/chrome-129/google-chrome --version | grep "129\."
     /opt/chromedriver-129/chromedriver --version | grep "129\."
 
     /opt/chrome-130/chrome --version | grep "130\."
+    /opt/chrome-130/google-chrome --version | grep "130\."
     /opt/chromedriver-130/chromedriver --version | grep "130\."
 
     if chrome; then
       echo "chrome should not be in PATH"
+      exit 1
+    fi
+
+    if google-chrome; then
+      echo "google-chrome should not be in PATH"
       exit 1
     fi
 
@@ -92,11 +105,7 @@
     install-chromedriver: true
 
 - key: verify--headed-chrome-works
-  use:
-    [
-      test--headed-and-headless-chrome-works--install-chrome,
-      test--headed-and-headless-chrome-works--install-ruby,
-    ]
+  use: [test--headed-and-headless-chrome-works--install-chrome, test--headed-and-headless-chrome-works--install-ruby]
   run: |
     cat << EOF > Gemfile
     source "https://rubygems.org"
@@ -127,11 +136,7 @@
     xvfb-run ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Google Search"
 
 - key: verify--headless-chrome-works
-  use:
-    [
-      test--headed-and-headless-chrome-works--install-chrome,
-      test--headed-and-headless-chrome-works--install-ruby,
-    ]
+  use: [test--headed-and-headless-chrome-works--install-chrome, test--headed-and-headless-chrome-works--install-ruby]
   run: |
     cat << EOF > Gemfile
     source "https://rubygems.org"
@@ -160,3 +165,33 @@
     bundle install
 
     ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Google Search"
+
+- key: test--testcafe-finds-chrome--install-node
+  call: mint/install-node 1.0.11
+  with:
+    node-version: 22.12.0
+
+- key: test--testcafe-finds-chrome--install-chrome
+  call: $LEAF_DIGEST
+  with:
+    chrome-version: stable
+    install-chromedriver: true
+
+- key: verify--testcafe-finds-chrome
+  use: [test--testcafe-finds-chrome--install-chrome, test--testcafe-finds-chrome--install-node]
+  run: |
+    # https://testcafe.io/documentation/402635/guides/overview/getting-started
+    cat << EOF > testcafe.test.js
+    import { Selector } from 'testcafe';
+
+    fixture('Getting Started').page('https://devexpress.github.io/testcafe/example');
+
+    test('My first test', async t => {
+      await t
+        .typeText('#developer-name', 'John Smith')
+        .click('#submit-button')
+        .expect(Selector('#article-header').innerText).eql('Thank you, John Smith!');
+    });
+    EOF
+
+    npx testcafe@3.7.1 chrome:headless testcafe.test.js

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 2.0.2
+version: 2.0.3
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -111,6 +111,7 @@ tasks:
 
       # Store useful chrome values
       chrome_binary="${CHROME_DIRECTORY}/chrome"
+      ln -s "${CHROME_DIRECTORY}/chrome" "${CHROME_DIRECTORY}/google-chrome"
 
       echo "Installed Chrome ${CHROME_VERSION}"
       "${chrome_binary}" --version


### PR DESCRIPTION
Tools like Karma and TestCafe expect a binary named `google-chrome` in the `PATH`