### PR TITLE
[mint/install-node] Change installation directory

### DIFF
--- a/mint/install-node/README.md
+++ b/mint/install-node/README.md
@@ -7,7 +7,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: mint/install-node 1.0.11
+    call: mint/install-node 1.1.0
     with:
       node-version: "21.4.0"
 ```
@@ -20,7 +20,7 @@ Or with a file named `.node-version` containing the version of node to install:
 tasks:
   - key: node
     use: code # or whichever task provides the .node-version file
-    call: mint/install-node 1.0.11
+    call: mint/install-node 1.1.0
     with:
       node-version-file: .node-version
     filter:

--- a/mint/install-node/bin/install-node
+++ b/mint/install-node/bin/install-node
@@ -77,9 +77,8 @@ esac
 
 echo "Detected ${os} OS on ${architecture} architecture"
 
-nodejs_dir="${MINT_LEAF_PATH}/nodejs"
-install_dir="${nodejs_dir}/v${NODE_VERSION}"
-source_dir="${nodejs_dir}/src"
+install_dir="/opt/node/v${NODE_VERSION}"
+source_dir=$(mktemp -d)
 source_file="node-v${NODE_VERSION}-${os}-${architecture}.tar.xz"
 download_url="https://nodejs.org/dist/v${NODE_VERSION}/${source_file}"
 shasums_url="https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt.asc"
@@ -90,8 +89,9 @@ function cleanup {
 }
 trap cleanup EXIT
 
-echo "Creating ${source_dir} and ${install_dir}"
-mkdir -p "$install_dir" "$source_dir"
+echo "Creating ${install_dir}"
+sudo mkdir -p "$install_dir"
+sudo chown ubuntu:ubuntu "$install_dir"
 cd "$source_dir"
 
 echo "Fetching and verifying SHASUMS256.txt.asc"

--- a/mint/install-node/mint-ci-cd.template.yml
+++ b/mint/install-node/mint-ci-cd.template.yml
@@ -30,3 +30,15 @@
 - key: test-install-22-10-0
   use: install-22-10-0
   run: node --version | grep '22\.10\.0'
+
+- key: test-npm-install-g
+  use: install-22-10-0
+  run: |
+    npm install -g yaml
+    npm root -g > $MINT_ENV/NODE_PATH
+
+- key: test-npm-install-g--assert
+  use: test-npm-install-g
+  run: |
+    echo 'require("yaml")' > code.js
+    node code.js

--- a/mint/install-node/mint-leaf.yml
+++ b/mint/install-node/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-node
-version: 1.0.11
+version: 1.1.0
 description: Install Node.js, the cross-platform JavaScript runtime environment
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/mint/install-node
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
This moves the installation directory for Node from the leaf directory to `/opt/node/v${version}`

Tested new leaf on Mint via [this run](https://cloud.rwx.com/mint/rwx/runs/45a78823b6bf4ce9b7e99190f9792891)