### PR TITLE
[mint/git-clone] Exclude the github token from the cache key

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.0
+    call: mint/git-clone 1.5.1
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.0
+    call: mint/git-clone 1.5.1
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.0
+    call: mint/git-clone 1.5.1
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.0
+    call: mint/git-clone 1.5.1
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/bin/git-clone
+++ b/mint/git-clone/bin/git-clone
@@ -2,6 +2,7 @@
 set -ueo pipefail
 
 mkdir -p "${CHECKOUT_PATH}"
+realpath -m --relative-to=. "${CHECKOUT_PATH}/.git" > $MINT_VALUES/git-dir-path
 cd "${CHECKOUT_PATH}"
 
 if [[ "${PRESERVE_GIT_DIR}" == "true" || "${FETCH_FULL_DEPTH}"  == "true" ]]; then

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.5.0
+version: 1.5.1
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -177,5 +177,7 @@ tasks:
       git config user.name $GIT_USERNAME
     env:
       CHECKOUT_PATH: ${{ params.path }}
-      GITHUB_TOKEN: ${{ params.github-access-token }}
+      GITHUB_TOKEN:
+        value: ${{ params.github-access-token }}
+        cache-key: excluded
       PRESERVE_GIT_DIR: ${{ params.preserve-git-dir }}

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -181,3 +181,5 @@ tasks:
         value: ${{ params.github-access-token }}
         cache-key: excluded
       PRESERVE_GIT_DIR: ${{ params.preserve-git-dir }}
+    filter:
+      - ${{ tasks.git-clone.values.git-dir-path }}


### PR DESCRIPTION
This will allow clones to be cache hits when large runs embed many other runs that do the same clones.