### PR TITLE
Add twingate/setup leaf

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -9,3 +9,4 @@ words:
   - xvfb
   - sonarsource
   - rustup
+  - twingate

--- a/twingate/setup/README.md
+++ b/twingate/setup/README.md
@@ -1,0 +1,11 @@
+# twingate/setup
+
+To install & setup the latest version of Twingate:
+
+ ```yaml
+ tasks:
+   - key: twingate
+     call: twingate/setup 1.0.0
+     with:
+       twingate-service-key: ${{ secrets.twingate-service-key }}
+ ```

--- a/twingate/setup/mint-ci-cd.template.yml
+++ b/twingate/setup/mint-ci-cd.template.yml
@@ -1,0 +1,11 @@
+- key: twingate--setup--test-default
+  call: $LEAF_DIGEST
+  with:
+    twingate-service-key:  ${{ vaults.mint_leaves_twingate_install_testing.secrets.twingate-service-key }}
+- key: twingate--setup--test-default--assert
+  use: twingate--setup--test-default
+  background-processes:
+    - key: twingate
+      run: sudo twingate start
+      ready-check: twingate status | grep online
+  run: twingate status | grep online

--- a/twingate/setup/mint-leaf.yml
+++ b/twingate/setup/mint-leaf.yml
@@ -1,0 +1,22 @@
+name: twingate/setup
+version: 1.0.0
+description: Install & setup Twingate
+source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/twingate/install
+issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
+
+parameters:
+   twingate-service-key:
+     description: 'A service key for Twingate'
+     required: true
+
+tasks:
+  - key: install
+    run: |
+      echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
+      sudo apt update -yq
+      sudo apt install -yq twingate
+  - key: setup
+    use: install
+    run: echo $TWINGATE_SERVICE_KEY | sudo twingate setup --headless=-
+    env:
+      TWINGATE_SERVICE_KEY: ${{ params.twingate-service-key }}


### PR DESCRIPTION
Example usage:

```
tasks:
  - key: twingate
    call: twingate/setup 1.0.0
    with:
      twingate-service-key: ${{ secrets.twingate-service-key }}
      
  - key: test
    use: twingate
    background-processes:                                                                            
     - key: twingate                                                                                
       run: sudo twingate start                                                                     
       ready-check: twingate status | grep online 
    run: |
       // do stuff here
```