### PR TITLE
Handle a ruby- prefix in .ruby-version

### DIFF
--- a/mint/install-ruby/README.md
+++ b/mint/install-ruby/README.md
@@ -1,6 +1,6 @@
 # mint/install-ruby
 
-We currently support Ruby versions 3.0.3 through 3.4.0. You'll either need to specify `ruby-version` or `ruby-version-file`.
+We currently support Ruby versions 3.0.3 through 3.4.1. You'll either need to specify `ruby-version` or `ruby-version-file`.
 
 ## With a .ruby-version file
 
@@ -9,7 +9,7 @@ If your project has a `.ruby-version` file:
 ```yaml
 tasks:
   - key: ruby
-    call: mint/install-ruby 1.1.5
+    call: mint/install-ruby 1.1.6
     with:
       ruby-version-file: .ruby-version
     filter: [.ruby-version]
@@ -24,7 +24,7 @@ If your project does not have a `.ruby-version` file, you can specify the versio
 ```yaml
 tasks:
   - key: ruby
-    call: mint/install-ruby 1.1.5
+    call: mint/install-ruby 1.1.6
     with:
       ruby-version: 3.4.1
 ```

--- a/mint/install-ruby/mint-ci-cd.template.yml
+++ b/mint/install-ruby/mint-ci-cd.template.yml
@@ -8,7 +8,7 @@
   run: ruby --version | grep 3.4.1
 
 - key: write-ruby-version-file
-  run: echo 3.4.0 > .ruby-version
+  run: echo 3.4.1 > .ruby-version
 
 - key: ruby-version-file
   use: write-ruby-version-file
@@ -18,7 +18,20 @@
 
 - key: ruby-version-file--assert
   use: ruby-version-file
-  run: ruby --version | grep 3.4.0
+  run: ruby --version | grep 3.4.1
+
+- key: write-prefixed-ruby-version-file
+  run: echo ruby-3.4.1 > .ruby-version
+
+- key: prefixed-ruby-version-file
+  use: write-prefixed-ruby-version-file
+  call: $LEAF_DIGEST
+  with:
+    ruby-version-file: .ruby-version
+
+- key: prefixed-ruby-version-file--assert
+  use: prefixed-ruby-version-file
+  run: ruby --version | grep 3.4.1
 
 - key: install-ruby--3-0
   call: $LEAF_DIGEST

--- a/mint/install-ruby/mint-leaf.yml
+++ b/mint/install-ruby/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-ruby
-version: 1.1.5
+version: 1.1.6
 description: Install Ruby, a dynamic programming language with a focus on simplicity and productivity
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/install-ruby
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -26,7 +26,7 @@ tasks:
           exit 2
         fi
 
-        RUBY_VERSION="$(cat "$RUBY_VERSION_FILE")"
+        RUBY_VERSION="$(cat "$RUBY_VERSION_FILE" | sed 's/ruby-//')"
         if [ "$RUBY_VERSION" = "" ]; then
           cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")
       Invalid parameters: the contents of \`ruby-version-file\` did not specify a Ruby version.


### PR DESCRIPTION
Bundler is more lenient than their docs would imply: https://github.com/rubygems/rubygems/blob/74f171a05cd02f14b7f0c00b3996089629480186/bundler/lib/bundler/ruby_dsl.rb#L30-L42

![CleanShot 2025-01-12 at 12 34 17@2x](https://github.com/user-attachments/assets/908531ed-a11b-4e92-a982-50dd53f41380)
