### PR TITLE
Emit warning of aws/assume-role deprecation

### DIFF
--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -115,3 +115,118 @@ tasks:
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
       profile-name: your-other-profile
 ```
+
+## Upgrading from v1.X.X
+
+In v1.X.X the AWS OIDC token was provided as a leaf parameter.
+Starting in version 2, the AWS OIDC token is provided to tasks that use the assume role leaf task as an environment variable (default: `AWS_OIDC_TOKEN`).
+
+As a result of this, upon retrying a task, a new token will be used, preventing the incidental use of expired credentials.
+
+### Assuming a Role
+
+#### Before
+
+```yaml
+tasks:
+  - key: aws-cli
+    call: aws/install-cli 1.0.1
+
+  - key: assume-role
+    use: aws-cli
+    call: aws/assume-role 1.1.4
+    with:
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-role
+      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
+
+  - key: your-task
+    use: assume-role
+    run: # ...
+```
+
+#### After
+
+```yaml
+tasks:
+  - key: aws-cli
+    call: aws/install-cli 1.0.1
+
+  - key: assume-role
+    use: aws-cli
+    call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
+    with:
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-role
+
+  - key: your-task
+    use: assume-role
+    run: ...
+    env:
+      AWS_OIDC_TOKEN:
+        value: ${{ vaults.your-vault.oidc.your-token }}
+        cache-key: excluded
+```
+
+### Role Chaining
+
+#### Before
+
+```yaml
+tasks:
+  - key: aws-cli
+    call: aws/install-cli 1.0.1
+
+  - key: assume-role
+    use: aws-cli
+    call: aws/assume-role 1.1.4
+    with:
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-role
+      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
+
+  - key: chain-role
+    use: assume-role
+    call: aws/assume-role 1.1.4
+    with:
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
+
+  - key: your-task
+    use: chain-role
+    run: ...
+```
+
+#### After
+
+```yaml
+tasks:
+  - key: aws-cli
+    call: aws/install-cli 1.0.1
+
+  - key: assume-role
+    use: aws-cli
+    call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
+    with:
+      oidc-token: ${{ vaults.your-vault.oidc.your-token }}
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-role
+
+  - key: chain-role
+    use: aws-cli
+    call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
+    with:
+      region: us-east-2
+      role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
+      role-chaining: true
+
+  - key: your-task
+    use: [assume-role, chain-role]
+    run: ...
+    env:
+      AWS_OIDC_TOKEN:
+        value: ${{ vaults.your-vault.oidc.your-token }}
+        cache-key: excluded
+```
+
+Note that `your-task` _uses_ both `assume-role` and `chain-role` in that order. It first assumes the role, then adds additional roles with  chaining.

--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -9,7 +9,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -25,7 +25,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -42,7 +42,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -59,7 +59,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -76,7 +76,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -84,7 +84,7 @@ tasks:
 
   - key: chained-role
     use: assume-role
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-other-role
@@ -99,7 +99,7 @@ tasks:
 
   - key: assume-role
     use: aws-cli
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
       region: us-east-2
@@ -108,7 +108,7 @@ tasks:
 
   - key: chained-role
     use: assume-role
-    call: aws/assume-role 1.1.3
+    call: aws/assume-role 1.1.4
     with:
       source-profile-name: your-profile
       region: us-east-2

--- a/aws/assume-role/README.md
+++ b/aws/assume-role/README.md
@@ -153,14 +153,13 @@ tasks:
     call: aws/install-cli 1.0.1
 
   - key: assume-role
-    use: aws-cli
     call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: your-task
-    use: assume-role
+    use: [aws-cli, assume-role]
     run: ...
     env:
       AWS_OIDC_TOKEN:
@@ -205,7 +204,6 @@ tasks:
     call: aws/install-cli 1.0.1
 
   - key: assume-role
-    use: aws-cli
     call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
     with:
       oidc-token: ${{ vaults.your-vault.oidc.your-token }}
@@ -213,7 +211,6 @@ tasks:
       role-to-assume: arn:aws:iam::your-account-id:role/your-role
 
   - key: chain-role
-    use: aws-cli
     call: aws/assume-role 2.0.0 # replaces aws/assume-role 1.1.4
     with:
       region: us-east-2
@@ -221,12 +218,10 @@ tasks:
       role-chaining: true
 
   - key: your-task
-    use: [assume-role, chain-role]
+    use: [aws-cli, assume-role, chain-role]
     run: ...
     env:
       AWS_OIDC_TOKEN:
         value: ${{ vaults.your-vault.oidc.your-token }}
         cache-key: excluded
 ```
-
-Note that `your-task` _uses_ both `assume-role` and `chain-role` in that order. It first assumes the role, then adds additional roles with  chaining.

--- a/aws/assume-role/mint-leaf.yml
+++ b/aws/assume-role/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: aws/assume-role
-version: 1.1.3
+version: 1.1.4
 description: Assume an AWS role
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/aws/assume-role
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -31,6 +31,11 @@ tasks:
   - key: assume-role
     run: |
       set -ueo pipefail
+
+      cat << EOF > $(mktemp "$MINT_WARNINGS/warning-XXXX")
+      This leaf is deprecated. Please upgrade to \`2.0.0\` or later.
+      Going forward the OIDC token is provided by downstream tasks via AWS_OIDC_TOKEN environment variable.
+      EOF
 
       if ! command -v aws &> /dev/null; then
         cat << EOF > $(mktemp "$MINT_ERRORS/error-XXXX")

--- a/aws/assume-role/mint-leaf.yml
+++ b/aws/assume-role/mint-leaf.yml
@@ -33,7 +33,7 @@ tasks:
       set -ueo pipefail
 
       cat << EOF > $(mktemp "$MINT_WARNINGS/warning-XXXX")
-      This leaf is being deprecated. Please upgrade to \`2.0.0\` or later. See [upgrade instructions](https://cloud.rwx.com/leaves/aws/assume-role) for more detail.
+      This leaf is deprecated. Please upgrade to \`2.0.0\` or later. See [upgrade instructions](https://cloud.rwx.com/leaves/aws/assume-role) for more detail.
       EOF
 
       if ! command -v aws &> /dev/null; then

--- a/aws/assume-role/mint-leaf.yml
+++ b/aws/assume-role/mint-leaf.yml
@@ -33,8 +33,7 @@ tasks:
       set -ueo pipefail
 
       cat << EOF > $(mktemp "$MINT_WARNINGS/warning-XXXX")
-      This leaf is deprecated. Please upgrade to \`2.0.0\` or later.
-      Going forward the OIDC token is provided by downstream tasks via AWS_OIDC_TOKEN environment variable.
+      This leaf is being deprecated. Please upgrade to \`2.0.0\` or later. See [upgrade instructions](https://cloud.rwx.com/leaves/aws/assume-role) for more detail.
       EOF
 
       if ! command -v aws &> /dev/null; then


### PR DESCRIPTION
Emit deprecation warning informing users of the incoming changes to aws/assume-role in #188 

Blocked by task emitted mint warnings rolling out to daily mint release.


<img width="1311" alt="image" src="https://github.com/user-attachments/assets/29edc1fc-5e01-400b-b934-f3f7e52402d0" />
