### PR TITLE
[mint/git-clone] Pull git submodules after initial clone.

### DIFF
--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.1
+    call: mint/git-clone 1.6.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.1
+    call: mint/git-clone 1.6.0
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.1
+    call: mint/git-clone 1.6.0
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.5.1
+    call: mint/git-clone 1.6.0
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/bin/git-clone
+++ b/mint/git-clone/bin/git-clone
@@ -5,7 +5,7 @@ mkdir -p "${CHECKOUT_PATH}"
 realpath -m --relative-to=. "${CHECKOUT_PATH}/.git" > $MINT_VALUES/git-dir-path
 cd "${CHECKOUT_PATH}"
 
-if [[ "${PRESERVE_GIT_DIR}" == "true" || "${FETCH_FULL_DEPTH}"  == "true" ]]; then
+if [[ "${PRESERVE_GIT_DIR}" == "true" || "${FETCH_FULL_DEPTH}" == "true" ]]; then
   CREDENTIAL_ARG=""
   if [[ "${CREDENTIAL_HELPER}" != "" ]]; then
     CREDENTIAL_ARG="-c credential.helper='${CREDENTIAL_HELPER}'"
@@ -25,6 +25,20 @@ fi
 
 commit_sha=$(git rev-parse HEAD | tr -d '\n')
 echo "Checked out git repository at ${commit_sha}"
+
+if [[ "${SUBMODULES}" == "true" && -f .gitmodules ]]; then
+  if [[ "${CREDENTIAL_HELPER}" != "" ]]; then
+    git config --global credential.helper "${CREDENTIAL_HELPER}"
+  fi
+
+  git submodule update --init --recursive
+
+  if [[ "${CREDENTIAL_HELPER}" != "" ]]; then
+    git config --global --unset credential.helper
+  fi
+
+  echo "Submodules initialized and updated"
+fi
 
 if [[ "${LFS}" == "true" ]]; then
   LFS_FILES=$(git-lfs ls-files -n)

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -4,6 +4,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-ssh-key--assert
   use: git-clone--test-ssh-key
@@ -73,6 +74,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-commit-sha-ref-meta--assert
   use: git-clone--test-commit-sha-ref-meta
@@ -91,6 +93,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: 4704503c51f6b5dd6346e219888488ed693dc54c
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-commit-sha-non-main-ref-meta--assert
   use: git-clone--test-commit-sha-non-main-ref-meta
@@ -109,6 +112,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: refs/heads/main
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-explicit-branch-ref-meta--assert
   use: git-clone--test-explicit-branch-ref-meta
@@ -127,6 +131,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: main
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-implicit-branch-ref-meta--assert
   use: git-clone--test-implicit-branch-ref-meta
@@ -145,6 +150,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: refs/tags/v1
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-explicit-tag-ref-meta--assert
   use: git-clone--test-explicit-tag-ref-meta
@@ -163,6 +169,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: v1
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-implicit-tag-ref-meta--assert
   use: git-clone--test-implicit-tag-ref-meta
@@ -182,6 +189,7 @@
     ref: v1
     meta-ref: main
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-meta-ref-override--assert
   use: git-clone--test-meta-ref-override
@@ -200,6 +208,7 @@
     repository: git@github.com:rwx-research/test-checkout-leaf.git
     ref: main
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
+    submodules: false
 
 - key: git-clone--test-ssh-repo-name--assert
   use: git-clone--test-ssh-repo-name
@@ -274,6 +283,7 @@
     ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
     lfs: true
+    submodules: false
 
 - key: git-clone--test-lfs-with-ssh-key--assert
   use: git-clone--test-lfs-with-ssh-key

--- a/mint/git-clone/mint-ci-cd.template.yml
+++ b/mint/git-clone/mint-ci-cd.template.yml
@@ -2,7 +2,7 @@
   call: $LEAF_DIGEST
   with:
     repository: git@github.com:rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
 
 - key: git-clone--test-ssh-key--assert
@@ -13,7 +13,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
 
 - key: git-clone--test-github-access-token--assert
@@ -49,7 +49,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     preserve-git-dir: true
 
@@ -71,7 +71,7 @@
   call: $LEAF_DIGEST
   with:
     repository: git@github.com:rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
 
 - key: git-clone--test-commit-sha-ref-meta--assert
@@ -234,7 +234,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     preserve-git-dir: true
     path: mint-leaves
@@ -258,7 +258,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     lfs: true
 
@@ -271,7 +271,7 @@
   call: $LEAF_DIGEST
   with:
     repository: git@github.com:rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     ssh-key: ${{ vaults.mint_leaves_development.secrets.CHECKOUT_LEAF_TEST_SSH_KEY }}
     lfs: true
 
@@ -284,7 +284,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     lfs: true
     preserve-git-dir: true
@@ -299,7 +299,7 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     lfs: true
     path: mint-leaves
@@ -313,10 +313,51 @@
   call: $LEAF_DIGEST
   with:
     repository: https://github.com/rwx-research/test-checkout-leaf.git
-    ref: 6bbbd5c26179155f7bc0d474155315cef6743d7d
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
     github-access-token: ${{ github.token }}
     fetch-full-depth: true
 
 - key: git-clone--test-fetch-full-depth--assert
   use: git-clone--test-fetch-full-depth
   run: test -e file-in-repo.txt
+
+- key: git-clone--test-submodules
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
+    github-access-token: ${{ github.token }}
+
+- key: git-clone--test-submodules--assert
+  use: git-clone--test-submodules
+  run: |
+    test -e test-checkout-leaf-submodule/README.md
+    test ! -d .git
+
+- key: git-clone--test-submodules-preserve-git-dir
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
+    github-access-token: ${{ github.token }}
+    preserve-git-dir: true
+
+- key: git-clone--test-submodules-preserve-git-dir--assert
+  use: git-clone--test-submodules-preserve-git-dir
+  run: |
+    test -e test-checkout-leaf-submodule/README.md
+    test -d .git
+
+- key: git-clone--test-submodules-false
+  call: $LEAF_DIGEST
+  with:
+    repository: https://github.com/rwx-research/test-checkout-leaf.git
+    ref: a3fee4b93f41402d25eae501958c46cb9576fe5d
+    github-access-token: ${{ github.token }}
+    submodules: false
+
+- key: git-clone--test-submodules-false--assert
+  use: git-clone--test-submodules-false
+  run: |
+    test -e test-checkout-leaf-submodule
+    test ! -e test-checkout-leaf-submodule/README.md

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.5.1
+version: 1.6.0
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -32,6 +32,9 @@ parameters:
   fetch-full-depth:
     description: "Whether to use a shallow fetch or a full-depth fetch when the repository is cloned and when not preserving the git directory (when `preserve-git-dir` is true, this parameter has no effect). Typically, setting this to `false` (the default) will result in better cloning performance within Mint. However, for certain large repositories, a full depth fetch may be faster."
     default: false
+  submodules:
+    description: Whether to clone submodules
+    default: true
 
 tasks:
   - key: setup
@@ -144,6 +147,7 @@ tasks:
       PRESERVE_GIT_DIR: ${{ params.preserve-git-dir }}
       CREDENTIAL_HELPER: ${{ tasks.setup.values.credential-helper }}
       FETCH_FULL_DEPTH: ${{ params.fetch-full-depth }}
+      SUBMODULES: ${{ params.submodules }}
 
   - key: configure-git
     use: [git-clone]


### PR DESCRIPTION
By default, git submodules are now pulled during a git clone. This can be disabled with `submodules: false`.

The tests using SSH key auth disable git submodules because the submodule was added via a `https:` URL.