### PR TITLE
Add cache ttls for abq and captain

### DIFF
--- a/mint/install-cli/README.md
+++ b/mint/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.5
+    call: mint/install-cli 1.0.6
 ```
 
 To install a specific version of the Mint CLI:
@@ -13,9 +13,9 @@ To install a specific version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.5
+    call: mint/install-cli 1.0.6
     with:
-      cli-version: v1.0.0
+      cli-version: v1.3.3
 ```
 
 For the list of available versions, see the releases on GitHub:

--- a/mint/install-cli/mint-ci-cd.template.yml
+++ b/mint/install-cli/mint-ci-cd.template.yml
@@ -1,12 +1,15 @@
-- key: install-cli--test-default
+- key: test-default
   call: $LEAF_DIGEST
-- key: install-cli--test-default--assert
-  use: install-cli--test-default
+
+- key: test-default--assert
+  use: test-default
   run: mint --version | grep 'mint version v1\.'
-- key: install-cli--test-specified
+
+- key: test-specified
   call: $LEAF_DIGEST
   with:
     cli-version: v0.0.12
-- key: install-cli--test-specified--assert
-  use: install-cli--test-specified
+
+- key: test-specified--assert
+  use: test-specified
   run: mint --version | grep 'mint version v0\.0\.12'

--- a/mint/install-cli/mint-leaf.yml
+++ b/mint/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-cli
-version: 1.0.5
+version: 1.0.6
 description: Install the Mint CLI
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/install-cli
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -10,23 +10,15 @@ parameters:
     default: "v1"
 
 tasks:
-  - key: cache-ttl
-    cache: false
-    run: |
-      if [[ "${{ params.cli-version }}" == "v1" ]]; then
-        date +%F | tee $MINT_VALUES/cache-ttl
-      else
-        echo "" | tee $MINT_VALUES/cache-ttl
-      fi
-
   - key: install
-    use: []
     run: |
-      version="${{ params.cli-version }}"
       tmp="$(mktemp -d)/mint"
-      curl -o "$tmp" -fsSL "https://github.com/rwx-research/mint-cli/releases/download/${version}/mint-linux-x86_64"
+      curl -o "$tmp" -fsSL "https://github.com/rwx-research/mint-cli/releases/download/${CLI_VERSION_PARAM}/mint-linux-x86_64"
       sudo install "$tmp" /usr/local/bin
       rm "$tmp"
       mint --version
+    cache:
+      enabled: true
+      ttl: 1 day
     env:
-      CACHE_TTL: ${{ tasks.cache-ttl.values.cache-ttl }}
+      CLI_VERSION_PARAM: ${{ params.cli-version }}

--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,9 +7,9 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.1.1
+    call: rwx/install-abq 1.1.2
 ```
 
-### ABQ Documentation:
+### ABQ Documentation
 
 https://www.rwx.com/docs/abq

--- a/rwx/install-abq/mint-ci-cd.template.yml
+++ b/rwx/install-abq/mint-ci-cd.template.yml
@@ -1,15 +1,15 @@
-- key: install-abq--test-default
+- key: test-default
   call: $LEAF_DIGEST
 
-- key: install-abq--test-default--assert
-  use: install-abq--test-default
+- key: test-default--assert
+  use: test-default
   run: abq --version | grep '^abq 1\.'
 
-- key: install-abq--test-with-token
+- key: test-with-token
   call: $LEAF_DIGEST
   with:
     rwx-access-token: ${{ vaults.mint_leaves_development.secrets.RWX_ACCESS_TOKEN }}
 
-- key: install-abq--test-with-token--assert
-  use: install-abq--test-with-token
+- key: test-with-token--assert
+  use: test-with-token
   run: abq --version | grep '^abq 1\.'

--- a/rwx/install-abq/mint-leaf.yml
+++ b/rwx/install-abq/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: rwx/install-abq
-version: 1.1.1
+version: 1.1.2
 description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/rwx/install-abq
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -12,13 +12,19 @@ parameters:
 tasks:
   - key: install
     run: |
-      if [[ "${{ params.rwx-access-token }}" != "" ]]; then
-        export RWX_ACCESS_TOKEN=${{ params.rwx-access-token }}
+      install_id=mint-$(date +%F)
+      if [[ "$RWX_ACCESS_TOKEN_PARAM" != "" ]]; then
+        export RWX_ACCESS_TOKEN="$RWX_ACCESS_TOKEN_PARAM"
       fi
       tmp="$(mktemp -d)/abq"
       curl -o $tmp -fsSL \
         -H "Authorization: Bearer $RWX_ACCESS_TOKEN" \
-        "https://cloud.rwx.com/abq/api/releases/v1/Linux/x86_64/abq?install_id=${{ run.id }}"
+        "https://cloud.rwx.com/abq/api/releases/v1/Linux/x86_64/abq?install_id=${install_id}"
       sudo install $tmp /usr/local/bin
       rm $tmp
       abq --version
+    cache:
+      enabled: true
+      ttl: 1 day
+    env:
+      RWX_ACCESS_TOKEN_PARAM: ${{ params.rwx-access-token }}

--- a/rwx/install-captain/README.md
+++ b/rwx/install-captain/README.md
@@ -9,7 +9,7 @@ To install the latest version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.0.2
+    call: rwx/install-captain 1.0.3
 ```
 
 To install a specific version of the Captain CLI:
@@ -17,9 +17,9 @@ To install a specific version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.0.2
+    call: rwx/install-captain 1.0.3
     with:
-      captain-version: v1.11.6
+      captain-version: v1.18.3
 ```
 
 For the list of available versions, see the releases on GitHub:

--- a/rwx/install-captain/mint-leaf.yml
+++ b/rwx/install-captain/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: rwx/install-captain
-version: 1.0.2
+version: 1.0.3
 description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/rwx/install-captain
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -13,7 +13,12 @@ tasks:
   - key: install
     run: |
       tmp="$(mktemp -d)/captain"
-      curl -o "$tmp" -fsSL "https://releases.captain.build/${{ params.captain-version }}/linux/x86_64/captain"
+      curl -o "$tmp" -fsSL "https://releases.captain.build/${CAPTAIN_VERSION}/linux/x86_64/captain"
       sudo install "$tmp" /usr/local/bin
       rm "$tmp"
       captain --version
+    cache:
+      enabled: true
+      ttl: 1 day
+    env:
+      CAPTAIN_VERSION: ${{ params.captain-version }}


### PR DESCRIPTION
Currently, the ABQ leaf downloads a binary for every run. This fixes that and uses the new cache TTL feature for Captain and Mint CLIs

https://www.rwx.com/docs/mint/caching#setting-ttls