### PR TITLE
Configure leaves to run against base permutations.

### DIFF
--- a/.mint/build-tasks.mjs
+++ b/.mint/build-tasks.mjs
@@ -30,7 +30,6 @@ async function exists(pathname) {
   }
 }
 
-
 for (const file of (await glob("*/*/mint-leaf.yml")).sort()) {
   const name = path.dirname(file);
   const key = name.replace("/", "-");

--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.4
+    call: google/install-chrome 2.0.5
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.4
+    call: google/install-chrome 2.0.5
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.0.4
+    call: google/install-chrome 2.0.5
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.0.4
+    call: google/install-chrome 2.0.5
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.4
+  call: google/install-chrome 2.0.5
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.4
+  call: google/install-chrome 2.0.5
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -110,7 +110,7 @@
     cat << EOF > Gemfile
     source "https://rubygems.org"
 
-    gem "selenium-webdriver", "~> 4.24"
+    gem "selenium-webdriver", "~> 4.30.1"
     EOF
 
     cat << EOF > selenium.rb
@@ -118,22 +118,28 @@
 
     options = Selenium::WebDriver::Options.chrome(args: [])
     driver = Selenium::WebDriver.for(:chrome, options:)
-    driver.navigate.to "http://google.com"
+    driver.navigate.to "https://www.bing.com"
 
-    element = driver.find_element(name: 'q')
-    element.send_keys "Hello WebDriver!"
-    element.submit
+    begin
+      element = driver.find_element(name: 'q')
+      element.send_keys "Hello WebDriver!"
+      element.submit
 
-    wait = Selenium::WebDriver::Wait.new(timeout: 10)
-    wait.until { !driver.title.nil? }
-    puts driver.title
+      wait = Selenium::WebDriver::Wait.new(timeout: 10)
+      wait.until { !driver.title.nil? }
+      puts driver.title
+    rescue
+      puts "Failed! Page contents:"
+      puts driver.page_source
+      raise
+    end
 
     driver.quit
     EOF
 
     bundle install
 
-    xvfb-run ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Google Search"
+    xvfb-run ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Search"
 
 - key: verify--headless-chrome-works
   use: [test--headed-and-headless-chrome-works--install-chrome, test--headed-and-headless-chrome-works--install-ruby]
@@ -141,30 +147,36 @@
     cat << EOF > Gemfile
     source "https://rubygems.org"
 
-    gem "selenium-webdriver", "~> 4.24"
+    gem "selenium-webdriver", "~> 4.30.1"
     EOF
 
     cat << EOF > selenium.rb
     require "selenium-webdriver"
 
-    options = Selenium::WebDriver::Options.chrome(args: ['--headless=new'])
+    options = Selenium::WebDriver::Options.chrome(args: ["--headless=new"])
     driver = Selenium::WebDriver.for(:chrome, options:)
-    driver.navigate.to "http://google.com"
+    driver.navigate.to "https://www.bing.com"
 
-    element = driver.find_element(name: 'q')
-    element.send_keys "Hello WebDriver!"
-    element.submit
+    begin
+      element = driver.find_element(name: 'q')
+      element.send_keys "Hello WebDriver!"
+      element.submit
 
-    wait = Selenium::WebDriver::Wait.new(timeout: 10)
-    wait.until { !driver.title.nil? }
-    puts driver.title
+      wait = Selenium::WebDriver::Wait.new(timeout: 10)
+      wait.until { !driver.title.nil? }
+      puts driver.title
+    rescue
+      puts "Failed! Page contents:"
+      puts driver.page_source
+      raise
+    end
 
     driver.quit
     EOF
 
     bundle install
 
-    ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Google Search"
+    ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Search"
 
 - key: test--testcafe-finds-chrome--install-node
   call: mint/install-node 1.1.0

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 2.0.4
+version: 2.0.5
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/mint/install-cli/README.md
+++ b/mint/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.4
+    call: mint/install-cli 1.0.5
 ```
 
 To install a specific version of the Mint CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Mint CLI:
 ```yaml
 tasks:
   - key: mint-cli
-    call: mint/install-cli 1.0.4
+    call: mint/install-cli 1.0.5
     with:
       cli-version: v1.0.0
 ```

--- a/mint/install-cli/mint-ci-cd.config.yml
+++ b/mint/install-cli/mint-ci-cd.config.yml
@@ -1,0 +1,13 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/mint/install-cli/mint-leaf.yml
+++ b/mint/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-cli
-version: 1.0.4
+version: 1.0.5
 description: Install the Mint CLI
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/install-cli
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/mint/install-erlang/README.md
+++ b/mint/install-erlang/README.md
@@ -5,7 +5,7 @@ To install Erlang:
 ```yaml
 tasks:
   - key: erlang
-    call: mint/install-erlang 1.0.0
+    call: mint/install-erlang 1.0.1
     with:
       erlang-version: 26.2.3
 ```

--- a/mint/install-erlang/mint-ci-cd.config.yml
+++ b/mint/install-erlang/mint-ci-cd.config.yml
@@ -1,13 +1,13 @@
 tests:
   - key: ubuntu-22-04-x86-64-1-0
-    template: mint-ci-cd.template.yml
+    template: ubuntu-22-04.yml
     base:
       os: ubuntu 22.04
       tag: 1.0
       arch: x86_64
 
   - key: ubuntu-24-04-x86-64-1-0
-    template: mint-ci-cd.template.yml
+    template: ubuntu-24-04.yml
     base:
       os: ubuntu 24.04
       tag: 1.0

--- a/mint/install-erlang/mint-ci-cd.config.yml
+++ b/mint/install-erlang/mint-ci-cd.config.yml
@@ -1,13 +1,13 @@
 tests:
   - key: ubuntu-22-04-x86-64-1-0
-    template: ubuntu-22-04.yml
+    template: mint-ci-cd.ubuntu-22-04.yml
     base:
       os: ubuntu 22.04
       tag: 1.0
       arch: x86_64
 
   - key: ubuntu-24-04-x86-64-1-0
-    template: ubuntu-24-04.yml
+    template: mint-ci-cd.ubuntu-24-04.yml
     base:
       os: ubuntu 24.04
       tag: 1.0

--- a/mint/install-erlang/mint-ci-cd.template.yml
+++ b/mint/install-erlang/mint-ci-cd.template.yml
@@ -1,5 +1,0 @@
-- key: test-ubuntu-22-04
-  call: ${{ tasks.generate-tests.artifacts.ubuntu-22-04 }}
-
-- key: test-ubuntu-24-04
-  call: ${{ tasks.generate-tests.artifacts.ubuntu-24-04 }}

--- a/mint/install-erlang/mint-ci-cd.template.yml
+++ b/mint/install-erlang/mint-ci-cd.template.yml
@@ -1,23 +1,5 @@
-- key: install-25-0-3
-  call: $LEAF_DIGEST
-  with:
-    erlang-version: 25.0.3
+- key: test-ubuntu-22-04
+  call: ${{ tasks.generate-tests.artifacts.ubuntu-22-04 }}
 
-- key: install-25-0-3--assert
-  use: install-25-0-3
-  run: |
-    cat "/usr/lib/erlang/releases/25/OTP_VERSION" | tee /dev/stderr | grep "^25\.0\.3$"
-
-    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^25\.0\.3$"
-
-- key: install-26-2-3
-  call: $LEAF_DIGEST
-  with:
-    erlang-version: 26.2.3
-
-- key: install-26-2-3--assert
-  use: install-26-2-3
-  run: |
-    cat "/usr/lib/erlang/releases/26/OTP_VERSION" | tee /dev/stderr | grep "^26\.2\.3$"
-
-    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^26\.2\.3$"
+- key: test-ubuntu-24-04
+  call: ${{ tasks.generate-tests.artifacts.ubuntu-24-04 }}

--- a/mint/install-erlang/mint-ci-cd.ubuntu-22-04.yml
+++ b/mint/install-erlang/mint-ci-cd.ubuntu-22-04.yml
@@ -1,28 +1,23 @@
-base:
-  os: ubuntu 22.04
-  tag: 1.0
+- key: install-25-0-3
+  call: $LEAF_DIGEST
+  with:
+    erlang-version: 25.0.3
 
-tasks:
-  - key: install-25-0-3
-    call: $LEAF_DIGEST
-    with:
-      erlang-version: 25.0.3
+- key: install-25-0-3--assert
+  use: install-25-0-3
+  run: |
+    cat "/usr/lib/erlang/releases/25/OTP_VERSION" | tee /dev/stderr | grep "^25\.0\.3$"
 
-  - key: install-25-0-3--assert
-    use: install-25-0-3
-    run: |
-      cat "/usr/lib/erlang/releases/25/OTP_VERSION" | tee /dev/stderr | grep "^25\.0\.3$"
+    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^25\.0\.3$"
 
-      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^25\.0\.3$"
+- key: install-26-2-3
+  call: $LEAF_DIGEST
+  with:
+    erlang-version: 26.2.3
 
-  - key: install-26-2-3
-    call: $LEAF_DIGEST
-    with:
-      erlang-version: 26.2.3
+- key: install-26-2-3--assert
+  use: install-26-2-3
+  run: |
+    cat "/usr/lib/erlang/releases/26/OTP_VERSION" | tee /dev/stderr | grep "^26\.2\.3$"
 
-  - key: install-26-2-3--assert
-    use: install-26-2-3
-    run: |
-      cat "/usr/lib/erlang/releases/26/OTP_VERSION" | tee /dev/stderr | grep "^26\.2\.3$"
-
-      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^26\.2\.3$"
+    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^26\.2\.3$"

--- a/mint/install-erlang/mint-ci-cd.ubuntu-22-04.yml
+++ b/mint/install-erlang/mint-ci-cd.ubuntu-22-04.yml
@@ -1,0 +1,28 @@
+base:
+  os: ubuntu 22.04
+  tag: 1.0
+
+tasks:
+  - key: install-25-0-3
+    call: $LEAF_DIGEST
+    with:
+      erlang-version: 25.0.3
+
+  - key: install-25-0-3--assert
+    use: install-25-0-3
+    run: |
+      cat "/usr/lib/erlang/releases/25/OTP_VERSION" | tee /dev/stderr | grep "^25\.0\.3$"
+
+      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^25\.0\.3$"
+
+  - key: install-26-2-3
+    call: $LEAF_DIGEST
+    with:
+      erlang-version: 26.2.3
+
+  - key: install-26-2-3--assert
+    use: install-26-2-3
+    run: |
+      cat "/usr/lib/erlang/releases/26/OTP_VERSION" | tee /dev/stderr | grep "^26\.2\.3$"
+
+      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^26\.2\.3$"

--- a/mint/install-erlang/mint-ci-cd.ubuntu-24-04.yml
+++ b/mint/install-erlang/mint-ci-cd.ubuntu-24-04.yml
@@ -1,0 +1,16 @@
+base:
+  os: ubuntu 24.04
+  tag: 1.0
+
+tasks:
+  - key: install-27-3
+    call: $LEAF_DIGEST
+    with:
+      erlang-version: '27.3'
+
+  - key: install-27-3--assert
+    use: install-27-3
+    run: |
+      cat "/usr/lib/erlang/releases/27/OTP_VERSION" | tee /dev/stderr | grep "^27\.3$"
+
+      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^27\.3$"

--- a/mint/install-erlang/mint-ci-cd.ubuntu-24-04.yml
+++ b/mint/install-erlang/mint-ci-cd.ubuntu-24-04.yml
@@ -1,16 +1,11 @@
-base:
-  os: ubuntu 24.04
-  tag: 1.0
+- key: install-27-3
+  call: $LEAF_DIGEST
+  with:
+    erlang-version: '27.3'
 
-tasks:
-  - key: install-27-3
-    call: $LEAF_DIGEST
-    with:
-      erlang-version: '27.3'
+- key: install-27-3--assert
+  use: install-27-3
+  run: |
+    cat "/usr/lib/erlang/releases/27/OTP_VERSION" | tee /dev/stderr | grep "^27\.3$"
 
-  - key: install-27-3--assert
-    use: install-27-3
-    run: |
-      cat "/usr/lib/erlang/releases/27/OTP_VERSION" | tee /dev/stderr | grep "^27\.3$"
-
-      erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^27\.3$"
+    erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell | tee /dev/stderr | grep "^27\.3$"

--- a/mint/install-erlang/mint-leaf.yml
+++ b/mint/install-erlang/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-erlang
-version: 1.0.0
+version: 1.0.1
 description: Install Erlang, a programming language used to build massively scalable soft real-time systems with requirements on high availability
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/mint/install-erlang
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -12,15 +12,31 @@ parameters:
 tasks:
   - key: packages
     run: |
+      if [ -f /etc/os-release ]; then
+        ubuntu_version=$(source /etc/os-release && echo "$VERSION_ID")
+      else
+        >&2 echo "Error: Cannot determine Ubuntu version"
+        exit 1
+      fi
+
+      if awk "BEGIN {exit !($ubuntu_version >= 24.04)}"; then
+        ncurses_package="libncurses6"
+      else
+        ncurses_package="libncurses5"
+      fi
+
       sudo apt-get update
-      sudo apt-get install libncurses5 libsctp1
+      sudo apt-get install libsctp1 "$ncurses_package"
       sudo apt-get clean
 
   - key: install
     use: packages
     run: |
-      file="esl-erlang_$ERLANG_VERSION-1~ubuntu~jammy_amd64.deb"
-      curl -fO "https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/$file"
+      version_codename="$(source /etc/os-release && echo "$VERSION_CODENAME")"
+      file="esl-erlang_${ERLANG_VERSION}-1~ubuntu~${version_codename}_amd64.deb"
+      url="https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/$file"
+      echo "Resolved source URL: $url"
+      curl -fO "$url"
       sudo dpkg -i "$file"
       rm "$file"
 


### PR DESCRIPTION
Allow leaves to run against different base permutations by adding a `mint-ci-cd.config.yml` to the leaf directory.

In some cases, we want to run the same tests against multiple base targets. In this case, put the tasks array into a file (here, `mint-ci-cd.template.yml`) and create `mint-ci-cd.config.yml`:

```yaml
tests:
  - key: ubuntu-22-04-x86-64-1-0
    template: mint-ci-cd.template.yml
    base:
      os: ubuntu 22.04
      tag: 1.0
      arch: x86_64

  - key: ubuntu-24-04-x86-64-1-0
    template: mint-ci-cd.template.yml
    base:
      os: ubuntu 24.04
      tag: 1.0
      arch: x86_64
```

In other cases, we want to run **different** tests against different base targets. Put the tasks array into different yaml files (here, `mint-ci-cd.ubuntu-22-04.yml` and `mint-ci-cd.ubuntu-24-04.yml`) and create `mint-ci-cd.config.yml`:

```yaml
tests:
  - key: ubuntu-22-04-x86-64-1-0
    template: mint-ci-cd.ubuntu-22-04.yml
    base:
      os: ubuntu 22.04
      tag: 1.0
      arch: x86_64

  - key: ubuntu-24-04-x86-64-1-0
    template: mint-ci-cd.ubuntu-24-04.yml
    base:
      os: ubuntu 24.04
      tag: 1.0
      arch: x86_64
```