### PR TITLE
Include `mint-utils.sh` helper functions with leaves.

### DIFF
--- a/mint-utils.sh
+++ b/mint-utils.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# mint-utils version 1.0.0
+
+detected_os=""
+detected_os_version=""
+detected_os_codename=""
+detected_arch=""
+
+function mint__detect_os_arch {
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+
+    detected_os="$ID"
+    detected_os_version="$VERSION_ID"
+    detected_os_codename="$VERSION_CODENAME"
+  fi
+
+  detected_arch=$(uname -m)
+}
+
+function mint_os_name {
+  if [ -z "$detected_os" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os"
+}
+
+function mint_os_version {
+  if [ -z "$detected_os_version" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os_version"
+}
+
+function mint_os_codename {
+  if [ -z "$detected_os_codename" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os_codename"
+}
+
+function mint_arch {
+  if [ -z "$detected_arch" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_arch"
+}
+
+function mint_arch_amd {
+  local arch
+  arch="$(mint_arch)"
+  if [ "$arch" = "x86_64" ]; then
+    echo "amd64"
+  else
+    echo "$arch"
+  fi
+}
+
+function mint_os_version_gte {
+  local compare_version="$1"
+  printf '%s\n' "$compare_version" "$(mint_os_version)" | sort -Vsc >/dev/null 2>&1
+}
+
+function mint_os_version_lte {
+  local compare_version="$1"
+  printf '%s\n' "$compare_version" "$(mint_os_version)" | sort -Vsc -r >/dev/null 2>&1
+}

--- a/mint/install-erlang/README.md
+++ b/mint/install-erlang/README.md
@@ -5,7 +5,7 @@ To install Erlang:
 ```yaml
 tasks:
   - key: erlang
-    call: mint/install-erlang 1.0.1
+    call: mint/install-erlang 1.0.2
     with:
       erlang-version: 26.2.3
 ```

--- a/mint/install-erlang/mint-leaf.yml
+++ b/mint/install-erlang/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-erlang
-version: 1.0.1
+version: 1.0.2
 description: Install Erlang, a programming language used to build massively scalable soft real-time systems with requirements on high availability
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/mint/install-erlang
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -12,14 +12,13 @@ parameters:
 tasks:
   - key: packages
     run: |
-      if [ -f /etc/os-release ]; then
-        ubuntu_version=$(source /etc/os-release && echo "$VERSION_ID")
-      else
-        >&2 echo "Error: Cannot determine Ubuntu version"
+      source "$MINT_LEAF_PATH/mint-utils.sh"
+      if [ "$(mint_os_name)" != "ubuntu" ]; then
+        echo "This leaf currently only supports Ubuntu." > $(mktemp "$MINT_ERRORS/error-XXXX")
         exit 1
       fi
 
-      if awk "BEGIN {exit !($ubuntu_version >= 24.04)}"; then
+      if mint_os_version_gte 24.04; then
         ncurses_package="libncurses6"
       else
         ncurses_package="libncurses5"
@@ -32,9 +31,9 @@ tasks:
   - key: install
     use: packages
     run: |
-      version_codename="$(source /etc/os-release && echo "$VERSION_CODENAME")"
-      file="esl-erlang_${ERLANG_VERSION}-1~ubuntu~${version_codename}_amd64.deb"
-      url="https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/$file"
+      source "$MINT_LEAF_PATH/mint-utils.sh"
+      file="esl-erlang_${ERLANG_VERSION}-1~$(mint_os_name)~$(mint_os_codename)_$(mint_arch_amd).deb"
+      url="https://binaries2.erlang-solutions.com/$(mint_os_name)/pool/contrib/e/esl-erlang/$file"
       echo "Resolved source URL: $url"
       curl -fO "$url"
       sudo dpkg -i "$file"

--- a/mint/install-erlang/mint-utils.sh
+++ b/mint/install-erlang/mint-utils.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# mint-utils version 1.0.0
+
+detected_os=""
+detected_os_version=""
+detected_os_codename=""
+detected_arch=""
+
+function mint__detect_os_arch {
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+
+    detected_os="$ID"
+    detected_os_version="$VERSION_ID"
+    detected_os_codename="$VERSION_CODENAME"
+  fi
+
+  detected_arch=$(uname -m)
+}
+
+function mint_os_name {
+  if [ -z "$detected_os" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os"
+}
+
+function mint_os_version {
+  if [ -z "$detected_os_version" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os_version"
+}
+
+function mint_os_codename {
+  if [ -z "$detected_os_codename" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_os_codename"
+}
+
+function mint_arch {
+  if [ -z "$detected_arch" ]; then
+    mint__detect_os_arch
+  fi
+  echo "$detected_arch"
+}
+
+function mint_arch_amd {
+  local arch
+  arch="$(mint_arch)"
+  if [ "$arch" = "x86_64" ]; then
+    echo "amd64"
+  else
+    echo "$arch"
+  fi
+}
+
+function mint_os_version_gte {
+  local compare_version="$1"
+  printf '%s\n' "$compare_version" "$(mint_os_version)" | sort -Vsc >/dev/null 2>&1
+}
+
+function mint_os_version_lte {
+  local compare_version="$1"
+  printf '%s\n' "$compare_version" "$(mint_os_version)" | sort -Vsc -r >/dev/null 2>&1
+}

--- a/render/deploy/README.md
+++ b/render/deploy/README.md
@@ -14,7 +14,7 @@ tasks:
 
   - key: deploy
     after: test
-    call: render/deploy 1.0.0
+    call: render/deploy 1.0.1
     with:
       ref: ${{ init.commit-sha }}
       render-api-key: ${{ vaults.your-vault.secrets.RENDER_API_KEY }}

--- a/render/deploy/mint-leaf.yml
+++ b/render/deploy/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: render/deploy
-version: 1.0.0
+version: 1.0.1
 description: Deploy to Render.com
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/render/deploy
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -66,7 +66,7 @@ tasks:
       SERVICE_ID: "${{ tasks.locate-service.values.service-id }}"
 
   - key: wait-for-completion
-    timeout-minutes: 10
+    timeout-minutes: 15
     run: |
       echo "Polling for deploy completion..."
       status=""


### PR DESCRIPTION
Add a script that can be used in a leaf to detect things like OS name, OS version, and version comparisons (`>=`, `<=`).

After discussing a few ways to share this script, Dan and I settled on manually copying it to leaves that use it. That way, they still become part of the leaf test/release cycle (unlike mounting them from an agent), and we aren't forced to do a version bump on every leaf at the same time.

I've included a version comment in the file so we can script a way to identify which leaves may want an update if a bug is detected in the helper script.