### PR TITLE
Test more leaves against Ubuntu 24.

### DIFF
--- a/azure/install-cli/README.md
+++ b/azure/install-cli/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Azure CLI:
 ```yaml
 tasks:
   - key: azure-cli
-    call: azure/install-cli 1.0.3
+    call: azure/install-cli 1.0.4
 ```
 
 To install a specific version of the Azure CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Azure CLI:
 ```yaml
 tasks:
   - key: azure-cli
-    call: azure/install-cli 1.0.3
+    call: azure/install-cli 1.0.4
     with:
       version: "2.65.0"
 ```

--- a/azure/install-cli/mint-ci-cd.config.yml
+++ b/azure/install-cli/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/azure/install-cli/mint-leaf.yml
+++ b/azure/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: azure/install-cli
-version: 1.0.3
+version: 1.0.4
 description: Install the Azure CLI
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/azure/install-cli
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/github/install-cli/README.md
+++ b/github/install-cli/README.md
@@ -5,5 +5,5 @@ To install the latest version of the GitHub CLI:
 ```yaml
 tasks:
   - key: github-cli
-    call: github/install-cli 1.0.3
+    call: github/install-cli 1.0.4
 ```

--- a/github/install-cli/mint-ci-cd.config.yml
+++ b/github/install-cli/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/github/install-cli/mint-leaf.yml
+++ b/github/install-cli/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: github/install-cli
-version: 1.0.3
+version: 1.0.4
 description: Install the GitHub CLI, gh. It is GitHub on the command line.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/github/install-cli
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/hashicorp/install-terraform/README.md
+++ b/hashicorp/install-terraform/README.md
@@ -5,7 +5,7 @@ To install the latest version of the Terraform CLI:
 ```yaml
 tasks:
   - key: terraform
-    call: hashicorp/install-terraform 1.0.4
+    call: hashicorp/install-terraform 1.0.5
 ```
 
 To install a specific version of the Terraform CLI:
@@ -13,7 +13,7 @@ To install a specific version of the Terraform CLI:
 ```yaml
 tasks:
   - key: terraform
-    call: hashicorp/install-terraform 1.0.4
+    call: hashicorp/install-terraform 1.0.5
     with:
       terraform-version: "1.7.3"
 ```

--- a/hashicorp/install-terraform/mint-ci-cd.config.yml
+++ b/hashicorp/install-terraform/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/hashicorp/install-terraform/mint-leaf.yml
+++ b/hashicorp/install-terraform/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: hashicorp/install-terraform
-version: 1.0.4
+version: 1.0.5
 description: Install the Terraform CLI, a tool for building, changing, and versioning infrastructure safely and efficiently
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/hashicorp/install-terraform
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/mint/git-clone/README.md
+++ b/mint/git-clone/README.md
@@ -5,7 +5,7 @@
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.6.3
+    call: mint/git-clone 1.6.4
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main
@@ -31,7 +31,7 @@ If you're using GitHub, Mint will automatically provide a token that you can use
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.6.3
+    call: mint/git-clone 1.6.4
     with:
       repository: https://github.com/YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -43,7 +43,7 @@ tasks:
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.6.3
+    call: mint/git-clone 1.6.4
     with:
       repository: git@github.com:YOUR_ORG/PROJECT.git
       ref: ${{ init.ref }}
@@ -61,7 +61,7 @@ If you need to reference one of these to alter behavior of a task, be sure to in
 ```yaml
 tasks:
   - key: code
-    call: mint/git-clone 1.6.3
+    call: mint/git-clone 1.6.4
     with:
       repository: https://github.com/YOUR_ORG/YOUR_REPO.git
       ref: main

--- a/mint/git-clone/mint-ci-cd.config.yml
+++ b/mint/git-clone/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/mint/git-clone/mint-leaf.yml
+++ b/mint/git-clone/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/git-clone
-version: 1.6.3
+version: 1.6.4
 description: Clone git repositories over ssh or http, with support for Git Large File Storage (LFS)
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/git-clone
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/mint/install-go/README.md
+++ b/mint/install-go/README.md
@@ -5,7 +5,7 @@ To install the latest version of go:
 ```yaml
 tasks:
   - key: go
-    call: mint/install-go 1.1.0
+    call: mint/install-go 1.1.1
 ```
 
 To install a specific version:
@@ -13,7 +13,7 @@ To install a specific version:
 ```yaml
 tasks:
   - key: go
-    call: mint/install-go 1.1.0
+    call: mint/install-go 1.1.1
     with:
       go-version: "1.21.5"
 ```

--- a/mint/install-go/mint-ci-cd.config.yml
+++ b/mint/install-go/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/mint/install-go/mint-leaf.yml
+++ b/mint/install-go/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-go
-version: 1.1.0
+version: 1.1.1
 description: Install the Go programming language
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/mint/install-go
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/mint/install-node/README.md
+++ b/mint/install-node/README.md
@@ -7,7 +7,7 @@ You'll either need to specify `node-version` or `node-version-file`
 ```yaml
 tasks:
   - key: node
-    call: mint/install-node 1.1.2
+    call: mint/install-node 1.1.3
     with:
       node-version: "21.4.0"
 ```
@@ -20,7 +20,7 @@ Or with a file named `.node-version` containing the version of node to install:
 tasks:
   - key: node
     use: code # or whichever task provides the .node-version file
-    call: mint/install-node 1.1.2
+    call: mint/install-node 1.1.3
     with:
       node-version-file: .node-version
     filter:

--- a/mint/install-node/mint-ci-cd.config.yml
+++ b/mint/install-node/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/mint/install-node/mint-leaf.yml
+++ b/mint/install-node/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: mint/install-node
-version: 1.1.2
+version: 1.1.3
 description: Install Node.js, the cross-platform JavaScript runtime environment
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/mint/install-node
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/rwx/install-abq/README.md
+++ b/rwx/install-abq/README.md
@@ -7,7 +7,7 @@ To install the ABQ CLI:
 ```yaml
 tasks:
   - key: abq
-    call: rwx/install-abq 1.1.2
+    call: rwx/install-abq 1.1.3
 ```
 
 ### ABQ Documentation

--- a/rwx/install-abq/mint-ci-cd.config.yml
+++ b/rwx/install-abq/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/rwx/install-abq/mint-leaf.yml
+++ b/rwx/install-abq/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: rwx/install-abq
-version: 1.1.2
+version: 1.1.3
 description: ABQ is a universal test runner that runs test suites in parallel. It’s the best tool for splitting test suites into parallel jobs in CI.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/rwx/install-abq
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/rwx/install-captain/README.md
+++ b/rwx/install-captain/README.md
@@ -9,7 +9,7 @@ To install the latest version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.0.3
+    call: rwx/install-captain 1.0.4
 ```
 
 To install a specific version of the Captain CLI:
@@ -17,7 +17,7 @@ To install a specific version of the Captain CLI:
 ```yaml
 tasks:
   - key: captain
-    call: rwx/install-captain 1.0.3
+    call: rwx/install-captain 1.0.4
     with:
       captain-version: v1.18.3
 ```

--- a/rwx/install-captain/mint-ci-cd.config.yml
+++ b/rwx/install-captain/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/rwx/install-captain/mint-leaf.yml
+++ b/rwx/install-captain/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: rwx/install-captain
-version: 1.0.3
+version: 1.0.4
 description: Captain is an open source CLI that can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more.
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/rwx/install-captain
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues

--- a/twingate/setup/README.md
+++ b/twingate/setup/README.md
@@ -5,7 +5,7 @@ To install & setup the latest version of Twingate:
  ```yaml
  tasks:
    - key: twingate
-     call: twingate/setup 1.0.3
+     call: twingate/setup 1.0.4
      with:
        twingate-service-key: ${{ secrets.twingate-service-key }}
  ```

--- a/twingate/setup/mint-ci-cd.config.yml
+++ b/twingate/setup/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/twingate/setup/mint-leaf.yml
+++ b/twingate/setup/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: twingate/setup
-version: 1.0.3
+version: 1.0.4
 description: Install & setup Twingate
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/twingate/setup
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues


### PR DESCRIPTION
This runs tests against both Ubuntu 22 and 24 for leaves that may depend on certain versions of apt packages, etc.

The remaining leaf not addressed here is `google/install-chrome` which needs changes and will be updated separately.