### PR TITLE
[google/install-chrome] Add support for Ubuntu 24.04; release v2.1.0

### DIFF
--- a/google/install-chrome/README.md
+++ b/google/install-chrome/README.md
@@ -12,7 +12,7 @@ Versions 115 and greater are supported.
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.7
+    call: google/install-chrome 2.1.0
     with:
       chrome-version: 130
 ```
@@ -22,7 +22,7 @@ tasks:
 ```yaml
 tasks:
   - key: chrome
-    call: google/install-chrome 2.0.7
+    call: google/install-chrome 2.1.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -35,7 +35,7 @@ If you are installing multiple versions of chrome and using them within the same
 ```yaml
 tasks:
   - key: chrome-129
-    call: google/install-chrome 2.0.7
+    call: google/install-chrome 2.1.0
     with:
       chrome-version: 129
       install-chromedriver: true
@@ -44,7 +44,7 @@ tasks:
       add-to-path: false
 
   - key: chrome-130
-    call: google/install-chrome 2.0.7
+    call: google/install-chrome 2.1.0
     with:
       chrome-version: 130
       install-chromedriver: true
@@ -68,7 +68,7 @@ By default, `google/install-chrome` supports tools that interact with Chrome in 
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.7
+  call: google/install-chrome 2.1.0
   with:
     chrome-version: stable
     install-chromedriver: true
@@ -117,7 +117,7 @@ You can also use tools that interact with headed Chrome. To do so, wrap your com
 
 ```yml
 - key: chrome
-  call: google/install-chrome 2.0.7
+  call: google/install-chrome 2.1.0
   with:
     chrome-version: stable
     install-chromedriver: true

--- a/google/install-chrome/mint-ci-cd.config.yml
+++ b/google/install-chrome/mint-ci-cd.config.yml
@@ -1,0 +1,14 @@
+tests:
+  - key: ubuntu-22-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 22.04
+      tag: 1.0
+      arch: x86_64
+
+  - key: ubuntu-24-04-x86-64-1-0
+    template: mint-ci-cd.template.yml
+    base:
+      os: ubuntu 24.04
+      tag: 1.0
+      arch: x86_64

--- a/google/install-chrome/mint-ci-cd.template.yml
+++ b/google/install-chrome/mint-ci-cd.template.yml
@@ -94,7 +94,7 @@
   run: chromedriver --version | grep '129\.'
 
 - key: test--headed-and-headless-chrome-works--install-ruby
-  call: mint/install-ruby 1.1.5
+  call: mint/install-ruby 1.2.0
   with:
     ruby-version: 3.3.4
 
@@ -179,7 +179,7 @@
     ruby selenium.rb | tee /dev/stderr | grep "Hello WebDriver! - Search"
 
 - key: test--testcafe-finds-chrome--install-node
-  call: mint/install-node 1.1.0
+  call: mint/install-node 1.1.3
   with:
     node-version: 22.12.0
 

--- a/google/install-chrome/mint-leaf.yml
+++ b/google/install-chrome/mint-leaf.yml
@@ -1,5 +1,5 @@
 name: google/install-chrome
-version: 2.0.7
+version: 2.1.0
 description: Install Google Chrome, the official web browser from Google
 source_code_url: https://github.com/rwx-research/mint-leaves/tree/main/google/install-chrome
 issue_tracker_url: https://github.com/rwx-research/mint-leaves/issues
@@ -32,8 +32,8 @@ tasks:
   - key: resolve-chrome-version
     run: |
       source "$MINT_LEAF_PATH/mint-utils.sh"
-      if ! mint_os_package_manager_in apt; then
-        echo "Unsupported operating system or package manager \`$(mint_os_package_manager)\`" > "$(mktemp "$MINT_ERRORS/error-XXXX")"
+      if ! mint_os_name_in ubuntu; then
+        echo "Unsupported operating system \`$(mint_os_name)\`" > "$(mktemp "$MINT_ERRORS/error-XXXX")"
         exit 1
       fi
 
@@ -78,24 +78,34 @@ tasks:
 
   - key: install
     run: |
+      source "$MINT_LEAF_PATH/mint-utils.sh"
+      os_packages=""
+      if mint_os_version_gte 24.04; then
+        os_packages="libasound2t64 libgtk-4-1 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcups2t64 libglib2.0-0t64 libgtk-3-0t64"
+      else
+        os_packages="libasound2 libgtk-3-0 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcups2 libglib2.0-0 libgtk-3-0"
+      fi
+
       echo "Installing Chrome system dependencies"
       sudo apt-get update
-      sudo apt-get install \
-        libglib2.0-0 \
-        libgconf-2-4 \
-        libatk1.0-0 \
-        libatk-bridge2.0-0 \
-        libgdk-pixbuf2.0-0 \
-        libgtk-3-0 \
-        libgbm-dev \
-        libnss3-dev \
-        libxss-dev \
-        libasound2 \
-        xvfb \
+
+      sudo apt-get install --no-upgrade $os_packages \
+        ca-certificates \
         fonts-liberation \
-        libu2f-udev \
+        libcairo2 \
+        libcurl4 \
+        libdbus-1-3 \
+        libexpat1 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libudev1 \
+        libvulkan1 \
+        x11-utils \
         xdg-utils \
-        x11-utils
+        xvfb
       sudo apt-get clean
 
       path_additions=""

--- a/google/install-chrome/mint-utils.sh
+++ b/google/install-chrome/mint-utils.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mint-utils version 1.0.3
+# mint-utils version 1.0.4
 
 detected_os=""
 detected_os_version=""
@@ -104,6 +104,10 @@ function mint_contains {
     fi
   done
   return 1
+}
+
+function mint_os_name_in {
+  mint_contains "$(mint_os_name)" "$@"
 }
 
 function mint_os_package_manager_in {


### PR DESCRIPTION
Package dependencies were taken from the current Chrome `.deb` and cut down a bit (since we're using `xvfb` and only a few X11 tools, not a full X11 server).